### PR TITLE
Generalize Umlego Workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 input_data
+output-*
 
 *.class
 

--- a/src/main/java/ch/sbb/matsim/umlego/AbstractWorker.java
+++ b/src/main/java/ch/sbb/matsim/umlego/AbstractWorker.java
@@ -4,6 +4,9 @@ import ch.sbb.matsim.umlego.matrix.ZoneNotFoundException;
 
 import java.util.concurrent.BlockingQueue;
 
+/**
+ * Base class for workers that process work items from a blocking queue.
+ */
 public abstract class AbstractWorker implements Runnable {
 
     protected final BlockingQueue<WorkItem> workerQueue;

--- a/src/main/java/ch/sbb/matsim/umlego/AbstractWorker.java
+++ b/src/main/java/ch/sbb/matsim/umlego/AbstractWorker.java
@@ -1,0 +1,34 @@
+package ch.sbb.matsim.umlego;
+
+import ch.sbb.matsim.umlego.matrix.ZoneNotFoundException;
+
+import java.util.concurrent.BlockingQueue;
+
+public abstract class AbstractWorker implements Runnable {
+
+    protected final BlockingQueue<WorkItem> workerQueue;
+
+    protected AbstractWorker(BlockingQueue<WorkItem> workerQueue) {
+        this.workerQueue = workerQueue;
+    }
+
+    @Override
+    public final void run() {
+        while (true) {
+            WorkItem item = null;
+            try {
+                item = this.workerQueue.take();
+                if (item.originZone() == null) {
+                    return;
+                }
+                WorkResult result = processOriginZone(item);
+                item.result().complete(result);
+            } catch (InterruptedException | ZoneNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    abstract protected WorkResult processOriginZone(WorkItem item);
+
+}

--- a/src/main/java/ch/sbb/matsim/umlego/FoundRoute.java
+++ b/src/main/java/ch/sbb/matsim/umlego/FoundRoute.java
@@ -1,0 +1,21 @@
+package ch.sbb.matsim.umlego;
+
+public class FoundRoute {
+    public final Stop2StopRoute stop2stopRoute;
+    public final ZoneConnections.ConnectedStop originConnectedStop;
+    public final ZoneConnections.ConnectedStop destinationConnectedStop;
+    public final double travelTimeWithAccess;
+
+    public double searchImpedance = Double.NaN; // Suchwiderstand
+    public double perceivedJourneyTimeMin = Double.NaN; // Empfundene Reisezeit
+    public double demand = 0;
+    public double adaptationTime = 0;
+    public double originality = 0; // Eigenständigkeit
+
+    public FoundRoute(Stop2StopRoute stop2stopRoute, ZoneConnections.ConnectedStop originConnectedStop, ZoneConnections.ConnectedStop destinationConnectedStop) {
+        this.stop2stopRoute = stop2stopRoute;
+        this.originConnectedStop = originConnectedStop;
+        this.destinationConnectedStop = destinationConnectedStop;
+        this.travelTimeWithAccess = stop2stopRoute.travelTimeWithoutAccess + originConnectedStop.walkTime() + destinationConnectedStop.walkTime();
+    }
+}

--- a/src/main/java/ch/sbb/matsim/umlego/Stop2StopRoute.java
+++ b/src/main/java/ch/sbb/matsim/umlego/Stop2StopRoute.java
@@ -1,0 +1,136 @@
+package ch.sbb.matsim.umlego;
+
+import ch.sbb.matsim.routing.pt.raptor.RaptorRoute;
+import org.matsim.core.utils.misc.Time;
+import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class Stop2StopRoute {
+    public final TransitStopFacility originStop;
+    public final TransitStopFacility destinationStop;
+    public final double depTime;
+    public final double arrTime;
+    public final double travelTimeWithoutAccess;
+    public final int transfers;
+    public final double distance;
+    public final List<RaptorRoute.RoutePart> routeParts = new ArrayList<>();
+
+    public Stop2StopRoute(RaptorRoute route) {
+        double firstDepTime = Double.NaN;
+        double lastArrTime = Double.NaN;
+
+        TransitStopFacility originStopFacility = null;
+        TransitStopFacility destinationStopFacility = null;
+
+        double distanceSum = 0;
+        RaptorRoute.RoutePart prevTransfer = null;
+        int stageCount = 0;
+        for (RaptorRoute.RoutePart part : route.getParts()) {
+            if (part.line == null) {
+                // it is a transfer
+                prevTransfer = part;
+                // still update the destination stop in case we arrive the destination by a transfer / walk-link
+                destinationStopFacility = part.toStop;
+            } else {
+                stageCount++;
+                if (routeParts.isEmpty()) {
+                    // it is the first real stage
+                    firstDepTime = part.vehicleDepTime;
+                    originStopFacility = part.fromStop;
+                } else if (prevTransfer != null) {
+                    this.routeParts.add(prevTransfer);
+                }
+                this.routeParts.add(part);
+                lastArrTime = part.arrivalTime;
+                destinationStopFacility = part.toStop;
+                distanceSum += part.distance;
+            }
+        }
+        this.originStop = originStopFacility;
+        this.destinationStop = destinationStopFacility;
+        this.depTime = firstDepTime;
+        this.arrTime = lastArrTime;
+        this.travelTimeWithoutAccess = this.arrTime - this.depTime;
+        this.transfers = stageCount - 1;
+        this.distance = distanceSum;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Stop2StopRoute that = (Stop2StopRoute) o;
+        boolean isEqual = Double.compare(depTime, that.depTime) == 0
+                && Double.compare(arrTime, that.arrTime) == 0
+                && transfers == that.transfers
+                && Objects.equals(originStop.getId(), that.originStop.getId())
+                && Objects.equals(destinationStop.getId(), that.destinationStop.getId());
+        if (isEqual) {
+            // also check route parts
+            for (int i = 0; i < routeParts.size(); i++) {
+                RaptorRoute.RoutePart routePartThis = this.routeParts.get(i);
+                RaptorRoute.RoutePart routePartThat = that.routeParts.get(i);
+
+                boolean partIsEqual =
+                        ((routePartThis.line == null && routePartThat.line == null) || (routePartThis.line != null
+                                && routePartThat.line != null && Objects.equals(routePartThis.line.getId(),
+                                routePartThat.line.getId())))
+                                && ((routePartThis.route == null && routePartThat.route == null) || (
+                                routePartThis.route != null && routePartThat.route != null && Objects.equals(
+                                        routePartThis.route.getId(), routePartThat.route.getId())));
+                if (!partIsEqual) {
+                    return false;
+                }
+            }
+        }
+        return isEqual;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(depTime, arrTime, transfers);
+    }
+
+    public String getRouteAsString() {
+        StringBuilder details = new StringBuilder();
+        for (RaptorRoute.RoutePart part : this.routeParts) {
+            if (part.line == null) {
+                continue;
+            }
+            if (!details.isEmpty()) {
+                details.append(", ");
+            }
+            details.append(getPartString(part));
+            while (part.chainedPart != null) {
+                part = part.chainedPart;
+                details.append(" => ");
+                details.append(getPartString(part));
+            }
+        }
+        return details.toString();
+    }
+
+    private String getPartString(RaptorRoute.RoutePart part) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(part.line.getId());
+        stringBuilder.append(" (");
+        stringBuilder.append(part.route.getId());
+        stringBuilder.append(") ");
+        stringBuilder.append(": ");
+        stringBuilder.append(part.fromStop.getName());
+        stringBuilder.append(' ');
+        stringBuilder.append(Time.writeTime(part.vehicleDepTime));
+        stringBuilder.append(" - ");
+        stringBuilder.append(part.toStop.getName());
+        stringBuilder.append(' ');
+        stringBuilder.append(Time.writeTime(part.arrivalTime));
+        return stringBuilder.toString();
+    }
+}

--- a/src/main/java/ch/sbb/matsim/umlego/Umlego.java
+++ b/src/main/java/ch/sbb/matsim/umlego/Umlego.java
@@ -163,7 +163,7 @@ public class Umlego {
 		   memory being used for the found routes until they get written. To prevent
 		   OutOfMemoryErrors, we use a blocking queue for the writer with a limited capacity.
 		 */
-        WorkItem workEndMarker = new WorkItem(null, null);
+        UmlegoWorkItem workEndMarker = new UmlegoWorkItem(null, null);
         CompletableFuture<WorkResult> writeEndMarker = new CompletableFuture<>();
         writeEndMarker.complete(new WorkResult(null, null, null));
 
@@ -192,9 +192,8 @@ public class Umlego {
         for (String originZoneId : originZoneIds) {
 
             try {
-                CompletableFuture<WorkResult> future = new CompletableFuture<>();
-                WorkItem workItem = new WorkItem(originZoneId, future);
-                writerQueue.put(future);
+                WorkItem workItem = workerFactory.createWorkItem(originZoneId);
+                writerQueue.put(workItem.result());
                 workerQueue.put(workItem);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);

--- a/src/main/java/ch/sbb/matsim/umlego/Umlego.java
+++ b/src/main/java/ch/sbb/matsim/umlego/Umlego.java
@@ -1,14 +1,10 @@
 package ch.sbb.matsim.umlego;
 
 import ch.sbb.matsim.routing.pt.raptor.RaptorParameters;
-import ch.sbb.matsim.routing.pt.raptor.RaptorRoute;
-import ch.sbb.matsim.routing.pt.raptor.RaptorRoute.RoutePart;
 import ch.sbb.matsim.routing.pt.raptor.RaptorStaticConfig;
 import ch.sbb.matsim.routing.pt.raptor.RaptorUtils;
 import ch.sbb.matsim.routing.pt.raptor.SwissRailRaptor;
 import ch.sbb.matsim.routing.pt.raptor.SwissRailRaptorData;
-import ch.sbb.matsim.umlego.UmlegoWorker.WorkItem;
-import ch.sbb.matsim.umlego.UmlegoWorker.WorkResult;
 import ch.sbb.matsim.umlego.ZoneConnections.ConnectedStop;
 import ch.sbb.matsim.umlego.config.UmlegoParameters;
 import ch.sbb.matsim.umlego.deltat.DeltaTCalculator;
@@ -20,8 +16,6 @@ import ch.sbb.matsim.umlego.matrix.DemandMatrices;
 import ch.sbb.matsim.umlego.matrix.ZoneNotFoundException;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
-import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
-import it.unimi.dsi.fastutil.objects.Object2DoubleOpenHashMap;
 
 import java.util.*;
 import java.util.concurrent.BlockingQueue;
@@ -31,7 +25,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matsim.api.core.v01.Scenario;
-import org.matsim.core.utils.misc.Time;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 
 /**
@@ -45,6 +38,7 @@ public class Umlego {
     private final Scenario scenario;
     private final Map<String, List<ConnectedStop>> stopsPerZone;
     private DeltaTCalculator deltaTCalculator = new IntervalBoundaries();
+    private WorkerFactory workerFactory = UmlegoWorker::new;
 
     /**
      * List of listeners to be notified about found routes.
@@ -64,10 +58,6 @@ public class Umlego {
         this.stopsPerZone = stopsPerZone;
     }
 
-    public void setDeltaTCalculator(DeltaTCalculator deltaTCalculator) {
-        this.deltaTCalculator = deltaTCalculator;
-    }
-
     /**
      * Adds a listener to be notified about found routes.
      *
@@ -79,6 +69,22 @@ public class Umlego {
         }
 
         this.listeners.add(listener);
+    }
+
+    /**
+     * Sets the {@link DeltaTCalculator} to be used for calculating adaptation times.
+     */
+    public Umlego setDeltaTCalculator(DeltaTCalculator deltaTCalculator) {
+        this.deltaTCalculator = deltaTCalculator;
+        return this;
+    }
+
+    /**
+     * Sets the {@link WorkerFactory} to be used for creating worker threads.
+     */
+    public Umlego setWorkerFactory(WorkerFactory workerFactory) {
+        this.workerFactory = workerFactory;
+        return this;
     }
 
     /**
@@ -168,9 +174,12 @@ public class Umlego {
         Thread[] threads = new Thread[threadCount];
         for (int i = 0; i < threads.length; i++) {
             SwissRailRaptor raptor = new SwissRailRaptor.Builder(raptorData, this.scenario.getConfig()).build();
-            threads[i] = new Thread(
-                new UmlegoWorker(workerQueue, params, this.demand, raptor, raptorParams, destinationZoneIds,
-                    this.stopsPerZone, stopLookupPerDestination, this.deltaTCalculator));
+
+            AbstractWorker worker = workerFactory.createWorker(
+                    workerQueue, params, this.demand, raptor, raptorParams, destinationZoneIds,
+                    this.stopsPerZone, stopLookupPerDestination, this.deltaTCalculator);
+
+            threads[i] = new Thread(worker);
             threads[i].start();
         }
 
@@ -183,8 +192,8 @@ public class Umlego {
         for (String originZoneId : originZoneIds) {
 
             try {
-                CompletableFuture<UmlegoWorker.WorkResult> future = new CompletableFuture<>();
-                UmlegoWorker.WorkItem workItem = new UmlegoWorker.WorkItem(originZoneId, future);
+                CompletableFuture<WorkResult> future = new CompletableFuture<>();
+                WorkItem workItem = new WorkItem(originZoneId, future);
                 writerQueue.put(future);
                 workerQueue.put(workItem);
             } catch (InterruptedException e) {
@@ -206,150 +215,4 @@ public class Umlego {
         demandWriter.write(unroutableDemand);
     }
 
-    public static class Stop2StopRoute {
-        public final TransitStopFacility originStop;
-        public final TransitStopFacility destinationStop;
-        public final double depTime;
-        public final double arrTime;
-        public final double travelTimeWithoutAccess;
-        public final int transfers;
-        public final double distance;
-        public final List<RaptorRoute.RoutePart> routeParts = new ArrayList<>();
-
-        public Stop2StopRoute(RaptorRoute route) {
-            double firstDepTime = Double.NaN;
-            double lastArrTime = Double.NaN;
-
-            TransitStopFacility originStopFacility = null;
-            TransitStopFacility destinationStopFacility = null;
-
-            double distanceSum = 0;
-            RaptorRoute.RoutePart prevTransfer = null;
-            int stageCount = 0;
-            for (RaptorRoute.RoutePart part : route.getParts()) {
-                if (part.line == null) {
-                    // it is a transfer
-                    prevTransfer = part;
-                    // still update the destination stop in case we arrive the destination by a transfer / walk-link
-                    destinationStopFacility = part.toStop;
-                } else {
-                    stageCount++;
-                    if (routeParts.isEmpty()) {
-                        // it is the first real stage
-                        firstDepTime = part.vehicleDepTime;
-                        originStopFacility = part.fromStop;
-                    } else if (prevTransfer != null) {
-                        this.routeParts.add(prevTransfer);
-                    }
-                    this.routeParts.add(part);
-                    lastArrTime = part.arrivalTime;
-                    destinationStopFacility = part.toStop;
-                    distanceSum += part.distance;
-                }
-            }
-            this.originStop = originStopFacility;
-            this.destinationStop = destinationStopFacility;
-            this.depTime = firstDepTime;
-            this.arrTime = lastArrTime;
-            this.travelTimeWithoutAccess = this.arrTime - this.depTime;
-            this.transfers = stageCount - 1;
-            this.distance = distanceSum;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            Stop2StopRoute that = (Stop2StopRoute) o;
-            boolean isEqual = Double.compare(depTime, that.depTime) == 0
-                && Double.compare(arrTime, that.arrTime) == 0
-                && transfers == that.transfers
-                && Objects.equals(originStop.getId(), that.originStop.getId())
-                && Objects.equals(destinationStop.getId(), that.destinationStop.getId());
-            if (isEqual) {
-                // also check route parts
-                for (int i = 0; i < routeParts.size(); i++) {
-                    RaptorRoute.RoutePart routePartThis = this.routeParts.get(i);
-                    RaptorRoute.RoutePart routePartThat = that.routeParts.get(i);
-
-                    boolean partIsEqual =
-                        ((routePartThis.line == null && routePartThat.line == null) || (routePartThis.line != null
-                            && routePartThat.line != null && Objects.equals(routePartThis.line.getId(),
-                            routePartThat.line.getId())))
-                            && ((routePartThis.route == null && routePartThat.route == null) || (
-                            routePartThis.route != null && routePartThat.route != null && Objects.equals(
-                                routePartThis.route.getId(), routePartThat.route.getId())));
-                    if (!partIsEqual) {
-                        return false;
-                    }
-                }
-            }
-            return isEqual;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(depTime, arrTime, transfers);
-        }
-
-        public String getRouteAsString() {
-            StringBuilder details = new StringBuilder();
-            for (RaptorRoute.RoutePart part : this.routeParts) {
-                if (part.line == null) {
-                    continue;
-                }
-                if (!details.isEmpty()) {
-                    details.append(", ");
-                }
-                details.append(getPartString(part));
-                while (part.chainedPart != null) {
-                    part = part.chainedPart;
-                    details.append(" => ");
-                    details.append(getPartString(part));
-                }
-            }
-            return details.toString();
-        }
-
-        private String getPartString(RoutePart part) {
-            StringBuilder stringBuilder = new StringBuilder();
-            stringBuilder.append(part.line.getId());
-            stringBuilder.append(" (");
-            stringBuilder.append(part.route.getId());
-            stringBuilder.append(") ");
-            stringBuilder.append(": ");
-            stringBuilder.append(part.fromStop.getName());
-            stringBuilder.append(' ');
-            stringBuilder.append(Time.writeTime(part.vehicleDepTime));
-            stringBuilder.append(" - ");
-            stringBuilder.append(part.toStop.getName());
-            stringBuilder.append(' ');
-            stringBuilder.append(Time.writeTime(part.arrivalTime));
-            return stringBuilder.toString();
-        }
-    }
-
-    public static class FoundRoute {
-        public final Stop2StopRoute stop2stopRoute;
-        public final ConnectedStop originConnectedStop;
-        public final ConnectedStop destinationConnectedStop;
-        public final double travelTimeWithAccess;
-
-        public double searchImpedance = Double.NaN; // Suchwiderstand
-        public double perceivedJourneyTimeMin = Double.NaN; // Empfundene Reisezeit
-        public double demand = 0;
-        public double adaptationTime = 0;
-        public double originality = 0; // Eigenständigkeit
-
-        public FoundRoute(Stop2StopRoute stop2stopRoute, ConnectedStop originConnectedStop, ConnectedStop destinationConnectedStop) {
-            this.stop2stopRoute = stop2stopRoute;
-            this.originConnectedStop = originConnectedStop;
-            this.destinationConnectedStop = destinationConnectedStop;
-            this.travelTimeWithAccess = stop2stopRoute.travelTimeWithoutAccess + originConnectedStop.walkTime() + destinationConnectedStop.walkTime();
-        }
-    }
 }

--- a/src/main/java/ch/sbb/matsim/umlego/UmlegoListener.java
+++ b/src/main/java/ch/sbb/matsim/umlego/UmlegoListener.java
@@ -1,7 +1,5 @@
 package ch.sbb.matsim.umlego;
 
-import ch.sbb.matsim.umlego.Umlego.FoundRoute;
-
 /**
  * Interface representing a listener for processing found routes.
  */

--- a/src/main/java/ch/sbb/matsim/umlego/UmlegoResultWorker.java
+++ b/src/main/java/ch/sbb/matsim/umlego/UmlegoResultWorker.java
@@ -2,9 +2,7 @@ package ch.sbb.matsim.umlego;
 
 import static ch.sbb.matsim.umlego.util.PathUtil.ensureDir;
 
-import ch.sbb.matsim.umlego.Umlego.FoundRoute;
 import ch.sbb.matsim.umlego.config.WriterParameters;
-import ch.sbb.matsim.umlego.UmlegoWorker.WorkResult;
 import ch.sbb.matsim.umlego.config.UmlegoWriterType;
 import ch.sbb.matsim.umlego.demand.UnroutableDemand;
 

--- a/src/main/java/ch/sbb/matsim/umlego/UmlegoRouteUtils.java
+++ b/src/main/java/ch/sbb/matsim/umlego/UmlegoRouteUtils.java
@@ -1,0 +1,139 @@
+package ch.sbb.matsim.umlego;
+
+import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Utility class for handling routes in the Umlego context.
+ */
+public class UmlegoRouteUtils {
+
+    private UmlegoRouteUtils() {
+        // Utility class, no instantiation
+    }
+
+    /**
+     * Checks if a route starts with a transfer within the same zone.
+     */
+    public static boolean routeStartsWithTransferWithinSameZone(Stop2StopRoute route, Set<TransitStopFacility> zoneStops) {
+        var firstRoutePart = route.routeParts.getFirst();
+        boolean isTransfer = route.originStop != firstRoutePart.fromStop;
+        if (isTransfer) {
+            // test if both the from and to stop are in the same zone
+            return zoneStops.contains(route.originStop) && zoneStops.contains(firstRoutePart.fromStop);
+        }
+        return false;
+    }
+
+    /**
+     * Checks if a route ends with a transfer within the same zone.
+     */
+    public static boolean routeEndsWithTransferWithinSameZone(Stop2StopRoute route, Set<TransitStopFacility> zoneStops) {
+        var lastRoutePart = route.routeParts.getLast();
+        boolean isTransfer = route.destinationStop != lastRoutePart.toStop;
+        if (isTransfer) {
+            // test if both the from and to stop are in the same zone
+            return zoneStops.contains(route.destinationStop) && zoneStops.contains(lastRoutePart.toStop);
+        }
+        return false;
+    }
+
+    /**
+     * Removes dominated routes from the list of routes.
+     * A route is dominated if there is another route that has a better or equal departure time,
+     * an earlier arrival time, fewer transfers, and a better search impedance.
+     */
+    public static void removeDominatedRoutes(List<FoundRoute> routes) {
+        // sort ascending by departure time, then descending by arrival time
+        // if a later route is fully contained in an earlier route, remove the earlier route except it is a direct route (no transfers)
+        routes.sort((o1, o2) -> {
+            if (o1.stop2stopRoute.depTime < o2.stop2stopRoute.depTime) {
+                return -1;
+            }
+            if (o1.stop2stopRoute.depTime > o2.stop2stopRoute.depTime) {
+                return +1;
+            }
+            if (o1.stop2stopRoute.arrTime < o2.stop2stopRoute.arrTime) {
+                return +1; // descending
+            }
+            if (o1.stop2stopRoute.arrTime > o2.stop2stopRoute.arrTime) {
+                return -1; // descending
+            }
+            return Integer.compare(o1.stop2stopRoute.transfers, o2.stop2stopRoute.transfers);
+        });
+
+        List<Integer> dominatedRouteIndices = new ArrayList<>(routes.size());
+        for (int route1Index = 0, n = routes.size(); route1Index < n; route1Index++) {
+            FoundRoute route1 = routes.get(route1Index);
+            if (route1.stop2stopRoute.transfers == 0) {
+                // always keep direct routes
+                continue;
+            }
+            for (int route2Index = route1Index + 1; route2Index < n; route2Index++) {
+                FoundRoute route2 = routes.get(route2Index);
+
+                if (route2.stop2stopRoute.depTime > route1.stop2stopRoute.arrTime) {
+                    // no further route can be contained in route 1
+                    break;
+                }
+
+                if (route2DominatesRoute1(route2, route1)) {
+                    dominatedRouteIndices.add(route1Index);
+                    break;
+                }
+            }
+        }
+
+        dominatedRouteIndices.sort((i1, i2) -> Integer.compare(i2, i1)); // reverse sort, descending
+        for (Integer routeIndex : dominatedRouteIndices) {
+            routes.remove(routeIndex.intValue());
+        }
+    }
+
+    private static boolean route2DominatesRoute1(FoundRoute route2, FoundRoute route1) {
+        boolean isContained = route2.stop2stopRoute.depTime >= route1.stop2stopRoute.depTime && route2.stop2stopRoute.arrTime <= route1.stop2stopRoute.arrTime;
+        boolean isStrictlyContained = isContained && (route2.stop2stopRoute.depTime > route1.stop2stopRoute.depTime || route2.stop2stopRoute.arrTime < route1.stop2stopRoute.arrTime);
+
+        boolean equalOrLessTransfers = route2.stop2stopRoute.transfers <= route1.stop2stopRoute.transfers;
+        boolean lessTransfers = route2.stop2stopRoute.transfers < route1.stop2stopRoute.transfers;
+
+        boolean equalOrBetterSearchImpedance = route1.searchImpedance >= 1.0 * route2.searchImpedance + 0.0;
+        boolean betterSearchImpedance = route1.searchImpedance > 1.0 * route2.searchImpedance + 0.0;
+
+        boolean hasStrictInequality = isStrictlyContained || lessTransfers || betterSearchImpedance;
+
+        return isContained && equalOrLessTransfers && equalOrBetterSearchImpedance && hasStrictInequality;
+    }
+
+    /**
+     * Sorts the routes in each list of foundRoutes by their departure time.
+     */
+    public static void sortRoutesByDepartureTime(Map<String, List<FoundRoute>> foundRoutes) {
+        for (List<FoundRoute> routes : foundRoutes.values()) {
+            routes.sort(UmlegoRouteUtils::compareFoundRoutesByDepartureTime);
+        }
+    }
+
+    /**
+     * Compares two FoundRoute objects by their departure time, travel time without access, and number of transfers.
+     */
+    public static int compareFoundRoutesByDepartureTime(FoundRoute o1, FoundRoute o2) {
+        if (o1.stop2stopRoute.depTime < o2.stop2stopRoute.depTime) {
+            return -1;
+        }
+        if (o1.stop2stopRoute.depTime > o2.stop2stopRoute.depTime) {
+            return +1;
+        }
+        if (o1.stop2stopRoute.travelTimeWithoutAccess < o2.stop2stopRoute.travelTimeWithoutAccess) {
+            return -1;
+        }
+        if (o1.stop2stopRoute.travelTimeWithoutAccess > o2.stop2stopRoute.travelTimeWithoutAccess) {
+            return +1;
+        }
+        return Integer.compare(o1.stop2stopRoute.transfers, o2.stop2stopRoute.transfers);
+    }
+}

--- a/src/main/java/ch/sbb/matsim/umlego/UmlegoSkimCalculator.java
+++ b/src/main/java/ch/sbb/matsim/umlego/UmlegoSkimCalculator.java
@@ -19,7 +19,6 @@
 
 package ch.sbb.matsim.umlego;
 
-import ch.sbb.matsim.umlego.Umlego.FoundRoute;
 import ch.sbb.matsim.umlego.writers.types.skim.*;
 
 import java.util.HashMap;

--- a/src/main/java/ch/sbb/matsim/umlego/UmlegoWorkItem.java
+++ b/src/main/java/ch/sbb/matsim/umlego/UmlegoWorkItem.java
@@ -1,0 +1,19 @@
+package ch.sbb.matsim.umlego;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Work item for Umlego, which contains one result per origin zone.
+ */
+public record UmlegoWorkItem(
+        String originZone,
+        List<CompletableFuture<WorkResult>> results
+) implements WorkItem {
+
+    @Override
+    public CompletableFuture<WorkResult> result() {
+        return results.getLast();
+    }
+
+}

--- a/src/main/java/ch/sbb/matsim/umlego/UmlegoWorker.java
+++ b/src/main/java/ch/sbb/matsim/umlego/UmlegoWorker.java
@@ -1,7 +1,5 @@
 package ch.sbb.matsim.umlego;
 
-import ch.sbb.matsim.umlego.Umlego.FoundRoute;
-import ch.sbb.matsim.umlego.Umlego.Stop2StopRoute;
 import ch.sbb.matsim.umlego.config.PerceivedJourneyTimeParameters;
 import ch.sbb.matsim.umlego.config.SearchImpedanceParameters;
 import ch.sbb.matsim.umlego.config.UmlegoParameters;
@@ -25,535 +23,400 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * @author mrieser / Simunto
  */
-public class UmlegoWorker implements Runnable {
+public class UmlegoWorker extends AbstractWorker {
 
-	private final BlockingQueue<WorkItem> workerQueue;
-	private final UmlegoParameters params;
-	private final DemandMatrices demand;
-	private final List<String> demandMatrixNames;
-	private final SwissRailRaptor raptor;
-	private final RaptorParameters raptorParams;
-	private final List<String> destinationZoneIds;
-	private final Map<String, List<ConnectedStop>> stopsPerZone;
-	private final Map<String, Map<TransitStopFacility, ConnectedStop>> stopLookupPerDestination;
-	private final RouteUtilityCalculator utilityCalculator;
-	private final DeltaTCalculator deltaTCalculator;
+    private final UmlegoParameters params;
+    private final DemandMatrices demand;
+    private final List<String> demandMatrixNames;
+    private final SwissRailRaptor raptor;
+    private final RaptorParameters raptorParams;
+    private final List<String> destinationZoneIds;
+    private final Map<String, List<ConnectedStop>> stopsPerZone;
+    private final Map<String, Map<TransitStopFacility, ConnectedStop>> stopLookupPerDestination;
+    private final RouteUtilityCalculator utilityCalculator;
+    private final DeltaTCalculator deltaTCalculator;
 
-	public UmlegoWorker(BlockingQueue<WorkItem> workerQueue,
-											UmlegoParameters params,
-											DemandMatrices demand,
-											SwissRailRaptor raptor,
-											RaptorParameters raptorParams,
-											List<String> destinationZoneIds,
-											Map<String, List<ConnectedStop>> stopsPerZone,
-											Map<String, Map<TransitStopFacility, ConnectedStop>> stopLookupPerDestination,
-											DeltaTCalculator deltaTCalculator) {
-		this.workerQueue = workerQueue;
-		this.params = params;
-		this.demand = demand;
-		this.demandMatrixNames = this.demand.getMatrixNames();
-		this.raptor = raptor;
-		this.raptorParams = raptorParams;
-		this.destinationZoneIds = destinationZoneIds;
-		this.stopsPerZone = stopsPerZone;
-		this.stopLookupPerDestination = stopLookupPerDestination;
-		this.utilityCalculator = params.routeSelection().utilityCalculator().createUtilityCalculator();
-		this.deltaTCalculator = deltaTCalculator;
-	}
+    public UmlegoWorker(BlockingQueue<WorkItem> workerQueue,
+                        UmlegoParameters params,
+                        DemandMatrices demand,
+                        SwissRailRaptor raptor,
+                        RaptorParameters raptorParams,
+                        List<String> destinationZoneIds,
+                        Map<String, List<ConnectedStop>> stopsPerZone,
+                        Map<String, Map<TransitStopFacility, ConnectedStop>> stopLookupPerDestination,
+                        DeltaTCalculator deltaTCalculator) {
+        super(workerQueue);
+        this.params = params;
+        this.demand = demand;
+        this.demandMatrixNames = this.demand.getMatrixNames();
+        this.raptor = raptor;
+        this.raptorParams = raptorParams;
+        this.destinationZoneIds = destinationZoneIds;
+        this.stopsPerZone = stopsPerZone;
+        this.stopLookupPerDestination = stopLookupPerDestination;
+        this.utilityCalculator = params.routeSelection().utilityCalculator().createUtilityCalculator();
+        this.deltaTCalculator = deltaTCalculator;
+    }
 
-	@Override
-    public void run() {
-		while (true) {
-			WorkItem item = null;
-			try {
-				item = this.workerQueue.take();
-				if (item.originZone == null) {
-					return;
-				}
-				WorkResult result = processOriginZone(item);
-				item.result.complete(result);
-			} catch (InterruptedException | ZoneNotFoundException e) {
-				throw new RuntimeException(e);
-			}
+    private static void calculateOriginality(List<FoundRoute> routes) {
+        routes.sort(UmlegoRouteUtils::compareFoundRoutesByDepartureTime);
+        for (int i = 0; i < routes.size(); i++) {
+            FoundRoute route1 = routes.get(i);
+            int countEqualRoutes = 1; // comparison with itself would always result in equality
+
+            // search for equal routes before this route
+            for (int j = i - 1; j >= 0; j--) {
+                FoundRoute route2 = routes.get(j);
+                if (route1.stop2stopRoute.depTime != route2.stop2stopRoute.depTime) {
+                    break; // because the routes are sorted, there cannot be any more equal routes
+                }
+
+                boolean areEqual = (route1.stop2stopRoute.depTime == route2.stop2stopRoute.depTime)
+                        && (route1.stop2stopRoute.arrTime == route2.stop2stopRoute.arrTime)
+                        && (route1.searchImpedance == route2.searchImpedance)
+                        && route1.stop2stopRoute.transfers == route2.stop2stopRoute.transfers;
+                if (areEqual) {
+                    countEqualRoutes++;
+                }
+            }
+            // search for equal routes after this route
+            for (int j = i + 1; j < routes.size(); j++) {
+                FoundRoute route2 = routes.get(j);
+                if (route1.stop2stopRoute.depTime != route2.stop2stopRoute.depTime) {
+                    break; // because the routes are sorted, there cannot be any more equal routes
+                }
+
+                boolean areEqual = (route1.stop2stopRoute.depTime == route2.stop2stopRoute.depTime)
+                        && (route1.stop2stopRoute.arrTime == route2.stop2stopRoute.arrTime)
+                        && (route1.searchImpedance == route2.searchImpedance)
+                        && route1.stop2stopRoute.transfers == route2.stop2stopRoute.transfers;
+                if (areEqual) {
+                    countEqualRoutes++;
+                }
+            }
+            route1.originality = 1.0 / countEqualRoutes;
         }
-	}
+    }
 
-	private WorkResult processOriginZone(WorkItem workItem) throws ZoneNotFoundException {
-		Map<String, List<FoundRoute>> foundRoutes = calculateRoutesForZone(workItem.originZone);
-		calculateRouteCharacteristics(foundRoutes);
-		filterRoutes(foundRoutes);
-		calculateOriginality(foundRoutes);
-		return assignDemand(workItem.originZone, foundRoutes);
-	}
+    @Override
+    protected WorkResult processOriginZone(WorkItem workItem) throws ZoneNotFoundException {
+        Map<String, List<FoundRoute>> foundRoutes = calculateRoutesForZone(workItem.originZone());
+        calculateRouteCharacteristics(foundRoutes);
+        filterRoutes(foundRoutes);
+        calculateOriginality(foundRoutes);
+        return assignDemand(workItem.originZone(), foundRoutes);
+    }
 
-	private Map<String, List<FoundRoute>> calculateRoutesForZone(String originZone) throws ZoneNotFoundException {
-		IntSet activeDestinationStopIndices = getActiveDestinationStopIndices(originZone);
-		Map<TransitStopFacility, Map<TransitStopFacility, Map<Stop2StopRoute, Boolean>>> foundRoutes = new HashMap<>();
-		for (ConnectedStop stop : stopsPerZone.getOrDefault(originZone, Collections.emptyList())) {
-			calcRoutesFromStop(stop.stopFacility(), activeDestinationStopIndices, foundRoutes);
-		}
-		return aggregateOnZoneLevel(originZone, foundRoutes);
-	}
+    protected final Map<String, List<FoundRoute>> calculateRoutesForZone(String originZone) throws ZoneNotFoundException {
+        IntSet activeDestinationStopIndices = getActiveDestinationStopIndices(originZone);
+        Map<TransitStopFacility, Map<TransitStopFacility, Map<Stop2StopRoute, Boolean>>> foundRoutes = new HashMap<>();
+        for (ConnectedStop stop : stopsPerZone.getOrDefault(originZone, Collections.emptyList())) {
+            calcRoutesFromStop(stop.stopFacility(), activeDestinationStopIndices, foundRoutes);
+        }
+        return aggregateOnZoneLevel(originZone, foundRoutes);
+    }
 
-	private IntSet getActiveDestinationStopIndices(String originZone) throws ZoneNotFoundException {
-		List<ConnectedStop> emptyList = Collections.emptyList();
-		IntSet destinationStopIndices = new IntOpenHashSet();
+    private IntSet getActiveDestinationStopIndices(String originZone) throws ZoneNotFoundException {
+        List<ConnectedStop> emptyList = Collections.emptyList();
+        IntSet destinationStopIndices = new IntOpenHashSet();
 
-		for (String destinationZone : this.destinationZoneIds) {
-			// exclude intrazonal demand
-			if (!destinationZone.equals(originZone)) {
-				for (String matrixName : this.demandMatrixNames) {
-					double value = this.demand.getMatrixValue(originZone, destinationZone, matrixName);
-					if (value > 0) {
-						List<TransitStopFacility> stops = this.stopsPerZone.getOrDefault(destinationZone, emptyList).stream().map(stop -> stop.stopFacility()).toList();
-						for (TransitStopFacility stop : stops) {
-							destinationStopIndices.add(stop.getId().index());
-						}
-						break;
-					}
-				}
-			}
-		}
-		return destinationStopIndices;
-	}
+        for (String destinationZone : this.destinationZoneIds) {
+            // exclude intrazonal demand
+            if (!destinationZone.equals(originZone)) {
+                for (String matrixName : this.demandMatrixNames) {
+                    double value = this.demand.getMatrixValue(originZone, destinationZone, matrixName);
+                    if (value > 0) {
+                        List<TransitStopFacility> stops = this.stopsPerZone.getOrDefault(destinationZone, emptyList).stream().map(stop -> stop.stopFacility()).toList();
+                        for (TransitStopFacility stop : stops) {
+                            destinationStopIndices.add(stop.getId().index());
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        return destinationStopIndices;
+    }
 
-	private void calcRoutesFromStop(TransitStopFacility originStop, IntSet destinationStopIndices, Map<TransitStopFacility, Map<TransitStopFacility, Map<Stop2StopRoute, Boolean>>> foundRoutes) {
-		this.raptorParams.setMaxTransfers(this.params.maxTransfers());
-		this.raptor.calcTreesObservable(
-				originStop,
-				0,
-				Double.POSITIVE_INFINITY,
-				this.raptorParams,
-				null,
-				(departureTime, arrivalStop, arrivalTime, transferCount, route) -> {
-					if (destinationStopIndices.contains(arrivalStop.getId().index())) {
-						Stop2StopRoute stop2stopRoute = new Stop2StopRoute(route.get());
-						if (stop2stopRoute.originStop != null) {
-							foundRoutes
-									.computeIfAbsent(stop2stopRoute.originStop, stop -> new HashMap<>())
-									.computeIfAbsent(stop2stopRoute.destinationStop, stop -> new HashMap<>())
-									.put(stop2stopRoute, Boolean.TRUE);
-						}
-					}
-				});
-	}
+    private void calcRoutesFromStop(TransitStopFacility originStop, IntSet destinationStopIndices, Map<TransitStopFacility, Map<TransitStopFacility, Map<Stop2StopRoute, Boolean>>> foundRoutes) {
+        this.raptorParams.setMaxTransfers(this.params.maxTransfers());
+        this.raptor.calcTreesObservable(
+                originStop,
+                0,
+                Double.POSITIVE_INFINITY,
+                this.raptorParams,
+                null,
+                (departureTime, arrivalStop, arrivalTime, transferCount, route) -> {
+                    if (destinationStopIndices.contains(arrivalStop.getId().index())) {
+                        Stop2StopRoute stop2stopRoute = new Stop2StopRoute(route.get());
+                        if (stop2stopRoute.originStop != null) {
+                            foundRoutes
+                                    .computeIfAbsent(stop2stopRoute.originStop, stop -> new HashMap<>())
+                                    .computeIfAbsent(stop2stopRoute.destinationStop, stop -> new HashMap<>())
+                                    .put(stop2stopRoute, Boolean.TRUE);
+                        }
+                    }
+                });
+    }
 
-	/**
-	 * Creates a Map containing for each destination zone id the List of found routes,
-	 * leading from the originZoneId to the destination, over the whole day.
-	 */
-	private Map<String, List<FoundRoute>> aggregateOnZoneLevel(String originZoneId, Map<TransitStopFacility, Map<TransitStopFacility, Map<Stop2StopRoute, Boolean>>> foundRoutesPerStop) {
-		List<ConnectedStop> emptyList = Collections.emptyList();
-		Map<String, List<FoundRoute>> foundRoutesPerZone = new HashMap<>();
+    /**
+     * Creates a Map containing for each destination zone id the List of found routes,
+     * leading from the originZoneId to the destination, over the whole day.
+     */
+    private Map<String, List<FoundRoute>> aggregateOnZoneLevel(String originZoneId, Map<TransitStopFacility, Map<TransitStopFacility, Map<Stop2StopRoute, Boolean>>> foundRoutesPerStop) {
+        List<ConnectedStop> emptyList = Collections.emptyList();
+        Map<String, List<FoundRoute>> foundRoutesPerZone = new HashMap<>();
 
-		List<ConnectedStop> stopsPerOriginZone = this.stopsPerZone.getOrDefault(originZoneId, emptyList);
-		Map<TransitStopFacility, ConnectedStop> originStopLookup = new HashMap<>();
-		for (ConnectedStop stop : stopsPerOriginZone) {
-			originStopLookup.put(stop.stopFacility(), stop);
-		}
+        List<ConnectedStop> stopsPerOriginZone = this.stopsPerZone.getOrDefault(originZoneId, emptyList);
+        Map<TransitStopFacility, ConnectedStop> originStopLookup = new HashMap<>();
+        for (ConnectedStop stop : stopsPerOriginZone) {
+            originStopLookup.put(stop.stopFacility(), stop);
+        }
 
-		for (String destinationZoneId : destinationZoneIds) {
-			Map<TransitStopFacility, ConnectedStop> destinationStopLookup = this.stopLookupPerDestination.get(destinationZoneId);
-			List<FoundRoute> allRoutesFromTo = new ArrayList<>();
-			for (ConnectedStop originStop : stopsPerOriginZone) {
-				Map<TransitStopFacility, Map<Stop2StopRoute, Boolean>> routesPerDestinationStop = foundRoutesPerStop.get(originStop.stopFacility());
-				if (routesPerDestinationStop != null) {
-					for (ConnectedStop destinationStop : this.stopsPerZone.getOrDefault(destinationZoneId, emptyList)) {
-						Map<Stop2StopRoute, Boolean> routesPerOriginDestinationStop = routesPerDestinationStop.get(destinationStop.stopFacility());
-						if (routesPerOriginDestinationStop != null) {
-							for (Stop2StopRoute route : routesPerOriginDestinationStop.keySet()) {
-								ConnectedStop originConnectedStop = originStopLookup.get(route.originStop);
-								ConnectedStop destinationConnectedStop = destinationStopLookup.get(route.destinationStop);
+        for (String destinationZoneId : destinationZoneIds) {
+            Map<TransitStopFacility, ConnectedStop> destinationStopLookup = this.stopLookupPerDestination.get(destinationZoneId);
+            List<FoundRoute> allRoutesFromTo = new ArrayList<>();
+            for (ConnectedStop originStop : stopsPerOriginZone) {
+                Map<TransitStopFacility, Map<Stop2StopRoute, Boolean>> routesPerDestinationStop = foundRoutesPerStop.get(originStop.stopFacility());
+                if (routesPerDestinationStop != null) {
+                    for (ConnectedStop destinationStop : this.stopsPerZone.getOrDefault(destinationZoneId, emptyList)) {
+                        Map<Stop2StopRoute, Boolean> routesPerOriginDestinationStop = routesPerDestinationStop.get(destinationStop.stopFacility());
+                        if (routesPerOriginDestinationStop != null) {
+                            for (Stop2StopRoute route : routesPerOriginDestinationStop.keySet()) {
+                                ConnectedStop originConnectedStop = originStopLookup.get(route.originStop);
+                                ConnectedStop destinationConnectedStop = destinationStopLookup.get(route.destinationStop);
 
-								boolean invalidRoute =
-										routeStartsWithTransferWithinSameZone(route, originStopLookup.keySet())
-										|| routeEndsWithTransferWithinSameZone(route, destinationStopLookup.keySet());
+                                boolean invalidRoute =
+                                        UmlegoRouteUtils.routeStartsWithTransferWithinSameZone(route, originStopLookup.keySet())
+                                                || UmlegoRouteUtils.routeEndsWithTransferWithinSameZone(route, destinationStopLookup.keySet());
 
-								if (originConnectedStop != null && destinationConnectedStop != null && !invalidRoute) {
-									// otherwise the route would not be valid, e.g. due to an additional transfer at the start or end
-									FoundRoute foundRoute = new FoundRoute(route, originConnectedStop, destinationConnectedStop);
-									allRoutesFromTo.add(foundRoute);
-								}
-							}
-						}
-					}
-				}
-			}
-			foundRoutesPerZone.put(destinationZoneId, allRoutesFromTo);
-		}
-		return foundRoutesPerZone;
-	}
+                                if (originConnectedStop != null && destinationConnectedStop != null && !invalidRoute) {
+                                    // otherwise the route would not be valid, e.g. due to an additional transfer at the start or end
+                                    FoundRoute foundRoute = new FoundRoute(route, originConnectedStop, destinationConnectedStop);
+                                    allRoutesFromTo.add(foundRoute);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            foundRoutesPerZone.put(destinationZoneId, allRoutesFromTo);
+        }
+        return foundRoutesPerZone;
+    }
 
-	private boolean routeStartsWithTransferWithinSameZone(Stop2StopRoute route, Set<TransitStopFacility> zoneStops) {
-		var firstRoutePart = route.routeParts.getFirst();
-		boolean isTransfer = route.originStop != firstRoutePart.fromStop;
-		if (isTransfer) {
-			// test if both the from and to stop are in the same zone
-			return zoneStops.contains(route.originStop) && zoneStops.contains(firstRoutePart.fromStop);
-		}
-		return false;
-	}
+    protected final void calculateOriginality(Map<String, List<FoundRoute>> foundRoutes) {
+        for (List<FoundRoute> routes : foundRoutes.values()) {
+            calculateOriginality(routes);
+        }
+    }
 
-	private boolean routeEndsWithTransferWithinSameZone(Stop2StopRoute route, Set<TransitStopFacility> zoneStops) {
-		var lastRoutePart = route.routeParts.getLast();
-		boolean isTransfer = route.destinationStop != lastRoutePart.toStop;
-		if (isTransfer) {
-			// test if both the from and to stop are in the same zone
-			return zoneStops.contains(route.destinationStop) && zoneStops.contains(lastRoutePart.toStop);
-		}
-		return false;
-	}
+    protected final void filterRoutes(Map<String, List<FoundRoute>> foundRoutes) {
+        for (List<FoundRoute> routes : foundRoutes.values()) {
+            filterRoutes(routes);
+        }
+    }
 
-	private void filterRoutes(Map<String, List<FoundRoute>> foundRoutes) {
-		for (List<FoundRoute> routes : foundRoutes.values()) {
-			filterRoutes(routes);
-		}
-	}
+    private void filterRoutes(List<FoundRoute> routes) {
+        UmlegoRouteUtils.removeDominatedRoutes(routes);
+        preselectRoute(routes);
+    }
 
-	private void filterRoutes(List<FoundRoute> routes) {
-		removeDominatedRoutes(routes);
-		preselectRoute(routes);
-	}
+    protected final void preselectRoute(List<FoundRoute> routes) {
+        int minTransfers = Integer.MAX_VALUE;
+        double minSearchImpedance = Double.POSITIVE_INFINITY;
+        double minTraveltime = Double.POSITIVE_INFINITY;
+        for (FoundRoute route : routes) {
+            if (route.stop2stopRoute.transfers < minTransfers) {
+                minTransfers = route.stop2stopRoute.transfers;
+            }
+            if (route.searchImpedance < minSearchImpedance) {
+                minSearchImpedance = route.searchImpedance;
+            }
+            if (route.travelTimeWithAccess < minTraveltime) {
+                minTraveltime = route.travelTimeWithAccess;
+            }
+        }
 
-	private void removeDominatedRoutes(List<FoundRoute> routes) {
-		// sort ascending by departure time, then descending by arrival time
-		// if a later route is fully contained in an earlier route, remove the earlier route except it is a direct route (no transfers)
-		routes.sort((o1, o2) -> {
-			if (o1.stop2stopRoute.depTime < o2.stop2stopRoute.depTime) {
-				return -1;
-			}
-			if (o1.stop2stopRoute.depTime > o2.stop2stopRoute.depTime) {
-				return +1;
-			}
-			if (o1.stop2stopRoute.arrTime < o2.stop2stopRoute.arrTime) {
-				return +1; // descending
-			}
-			if (o1.stop2stopRoute.arrTime > o2.stop2stopRoute.arrTime) {
-				return -1; // descending
-			}
-			return Integer.compare(o1.stop2stopRoute.transfers, o2.stop2stopRoute.transfers);
-		});
+        ListIterator<FoundRoute> it = routes.listIterator();
+        while (it.hasNext()) {
+            FoundRoute route = it.next();
+            if ((route.searchImpedance > (this.params.preselection().betaMinImpedance() * minSearchImpedance + this.params.preselection().constImpedance()))
+                    || (route.stop2stopRoute.transfers > (minTransfers + 3) && (route.travelTimeWithAccess > minTraveltime))
+            ) {
+                it.remove();
+            }
+        }
+    }
 
-		List<Integer> dominatedRouteIndices = new ArrayList<>(routes.size());
-		for (int route1Index = 0, n = routes.size(); route1Index < n; route1Index++) {
-			FoundRoute route1 = routes.get(route1Index);
-			if (route1.stop2stopRoute.transfers == 0) {
-				// always keep direct routes
-				continue;
-			}
-			for (int route2Index = route1Index + 1; route2Index < n; route2Index++) {
-				FoundRoute route2 = routes.get(route2Index);
+    protected final void calculateRouteCharacteristics(Map<String, List<FoundRoute>> foundRoutes) {
+        for (List<FoundRoute> routes : foundRoutes.values()) {
+            for (FoundRoute route : routes) {
+                calculateRouteCharacteristics(route);
+            }
+        }
+    }
 
-				if (route2.stop2stopRoute.depTime > route1.stop2stopRoute.arrTime) {
-					// no further route can be contained in route 1
-					break;
-				}
+    private void calculateRouteCharacteristics(FoundRoute route) {
+        double inVehicleTime = 0;
+        double accessTime = route.originConnectedStop.walkTime();
+        double egressTime = route.destinationConnectedStop.walkTime();
+        double walkTime = 0;
+        double transferWaitTime = 0;
+        double transferCount = route.stop2stopRoute.transfers;
 
-				if (route2DominatesRoute1(route2, route1)) {
-					dominatedRouteIndices.add(route1Index);
-					break;
-				}
-			}
-		}
+        boolean hadTransferBefore = false;
+        int additionalStopCount = 0;
+        for (RaptorRoute.RoutePart part : route.stop2stopRoute.routeParts) {
+            if (part.line == null) {
+                // it is a transfer
+                walkTime += (part.arrivalTime - part.depTime);
+                hadTransferBefore = true;
+            } else {
+                if (hadTransferBefore) {
+                    transferWaitTime += (part.vehicleDepTime - part.depTime);
+                }
+                inVehicleTime += (part.arrivalTime - part.vehicleDepTime);
+                hadTransferBefore = false;
+                int startIndex = -1;
+                int endIndex = -1;
+                List<TransitRouteStop> stops = part.route.getStops();
+                for (int i = 0; i < stops.size(); i++) {
+                    TransitRouteStop routeStop = stops.get(i);
+                    if (routeStop.getStopFacility().getId().equals(part.toStop.getId()) && startIndex >= 0) {
+                        endIndex = i;
+                        break;
+                    }
+                    if (routeStop.getStopFacility().getId().equals(part.fromStop.getId())) {
+                        startIndex = i;
+                    }
+                }
+                if (startIndex >= 0 && endIndex >= 0) {
+                    additionalStopCount += (endIndex - startIndex - 1);
+                }
+            }
+        }
 
-		dominatedRouteIndices.sort((i1, i2) -> Integer.compare(i2, i1)); // reverse sort, descending
-		for (Integer routeIndex : dominatedRouteIndices) {
-			routes.remove(routeIndex.intValue());
-		}
-	}
+        double expectedTotalTime = route.stop2stopRoute.routeParts.get(route.stop2stopRoute.routeParts.size() - 1).arrivalTime - route.stop2stopRoute.routeParts.get(0).vehicleDepTime;
+        if ((walkTime + transferWaitTime + inVehicleTime) != expectedTotalTime) {
+            System.err.println("INCONSISTENT TIMES " + route.stop2stopRoute.getRouteAsString());
+        }
+        double totalTravelTime = expectedTotalTime + accessTime + egressTime;
 
-	private void preselectRoute(List<FoundRoute> routes) {
-		int minTransfers = Integer.MAX_VALUE;
-		double minSearchImpedance = Double.POSITIVE_INFINITY;
-		double minTraveltime = Double.POSITIVE_INFINITY;
-		for (FoundRoute route : routes) {
-			if (route.stop2stopRoute.transfers < minTransfers) {
-				minTransfers = route.stop2stopRoute.transfers;
-			}
-			if (route.searchImpedance < minSearchImpedance) {
-				minSearchImpedance = route.searchImpedance;
-			}
-			if (route.travelTimeWithAccess < minTraveltime) {
-				minTraveltime = route.travelTimeWithAccess;
-			}
-		}
+        PerceivedJourneyTimeParameters pjtParams = this.params.pjt();
+        route.perceivedJourneyTimeMin = pjtParams.betaInVehicleTime() * (inVehicleTime / 60.0)
+                + pjtParams.betaAccessTime() * (accessTime / 60.0)
+                + pjtParams.betaEgressTime() * (egressTime / 60.0)
+                + pjtParams.betaWalkTime() * (walkTime / 60.0)
+                + pjtParams.betaTransferWaitTime() * (transferWaitTime / 60.0)
+                + transferCount * (pjtParams.transferFix() + pjtParams.transferTraveltimeFactor() * (totalTravelTime / 60.0))
+                + (pjtParams.secondsPerAdditionalStop() / 60.0) * additionalStopCount;
 
-		ListIterator<FoundRoute> it = routes.listIterator();
-		while (it.hasNext()) {
-			FoundRoute route = it.next();
-			if ((route.searchImpedance > (this.params.preselection().betaMinImpedance() * minSearchImpedance + this.params.preselection().constImpedance()))
-				|| (route.stop2stopRoute.transfers > (minTransfers + 3) && (route.travelTimeWithAccess > minTraveltime))
-			) {
-				it.remove();
-			}
-		}
-	}
+        SearchImpedanceParameters searchParams = this.params.search();
+        route.searchImpedance =
+                searchParams.betaInVehicleTime() * (inVehicleTime / 60.0)
+                        + searchParams.betaAccessTime() * (accessTime / 60.0)
+                        + searchParams.betaEgressTime() * (egressTime / 60.0)
+                        + searchParams.betaWalkTime() * (walkTime / 60.0)
+                        + searchParams.betaTransferWaitTime() * (transferWaitTime / 60.0)
+                        + searchParams.betaTransferCount() * transferCount;
+    }
 
-	private static boolean route2DominatesRoute1(FoundRoute route2, FoundRoute route1) {
-		boolean isContained = route2.stop2stopRoute.depTime >= route1.stop2stopRoute.depTime && route2.stop2stopRoute.arrTime <= route1.stop2stopRoute.arrTime;
-		boolean isStrictlyContained = isContained && (route2.stop2stopRoute.depTime > route1.stop2stopRoute.depTime || route2.stop2stopRoute.arrTime < route1.stop2stopRoute.arrTime);
+    protected final WorkResult assignDemand(String originZone, Map<String, List<FoundRoute>> foundRoutes) throws ZoneNotFoundException {
+        UmlegoRouteUtils.sortRoutesByDepartureTime(foundRoutes);
+        UnroutableDemand unroutableDemand = new UnroutableDemand();
+        for (String destinationZone : this.destinationZoneIds) {
+            var routes = foundRoutes.get(destinationZone);
+            if (routes == null || routes.isEmpty()) {
+                double sum = 0;
+                for (String matrixName : this.demandMatrixNames) {
+                    double value = this.demand.getMatrixValue(originZone, destinationZone, matrixName);
+                    sum += value;
+                }
+                if (sum > 0) {
+                    unroutableDemand.addPart(new UnroutableDemandPart(originZone, destinationZone, sum));
+                }
+            } else {
+                for (String matrixName : this.demandMatrixNames) {
+                    double value = this.demand.getMatrixValue(originZone, destinationZone, matrixName);
+                    if (value > 0) {
+                        int matrixNumber = Integer.parseInt(matrixName);
+                        double startTime = (matrixNumber - 1) * 10 * 60; // 10-minute time slots, in seconds TODO: make configurable
+                        double endTime = (matrixNumber) * 10 * 60;
+                        assignDemand(originZone, destinationZone, startTime, endTime, value, routes, unroutableDemand);
+                    }
+                }
+            }
+        }
+        return new WorkResult(originZone, foundRoutes, unroutableDemand);
+    }
 
-		boolean equalOrLessTransfers = route2.stop2stopRoute.transfers <= route1.stop2stopRoute.transfers;
-		boolean lessTransfers = route2.stop2stopRoute.transfers < route1.stop2stopRoute.transfers;
+    private void assignDemand(String originZone, String destinationZone, double startTime, double endTime, double odDemand, List<FoundRoute> routes, UnroutableDemand unroutableDemand) {
+        FoundRoute[] potentialRoutes;
+        boolean limit = this.params.routeSelection().limitSelectionToTimewindow();
+        if (limit) {
+            double earliestDeparture = startTime - this.params.routeSelection().beforeTimewindow();
+            double latestDeparture = endTime + this.params.routeSelection().afterTimewindow();
+            potentialRoutes = routes.stream().filter(route -> ((route.stop2stopRoute.depTime - route.originConnectedStop.walkTime()) >= earliestDeparture)
+                    && ((route.stop2stopRoute.depTime - route.originConnectedStop.walkTime() <= latestDeparture))).toList().toArray(new FoundRoute[0]);
+        } else {
+            potentialRoutes = routes.toArray(new FoundRoute[0]);
+        }
+        if (potentialRoutes.length == 0) {
+            unroutableDemand.addPart(new UnroutableDemandPart(originZone, destinationZone, odDemand));
+            return;
+        }
+        double timeWindow = endTime - startTime;
+        double stepSize = 60.0; // sample every minute
+        int samples = (int) (timeWindow / stepSize);
+        double sharePerSample = 1.0 / ((double) samples);
+        double[] impedances = new double[potentialRoutes.length];
+        double[] deltas = new double[potentialRoutes.length];
+        double minImpedance = Double.POSITIVE_INFINITY;
+        double[] routeUtilities = new double[potentialRoutes.length];
+        double betaPJT = this.params.impedance().betaPerceivedJourneyTime();
+        double betaDeltaTEarly = this.params.impedance().betaDeltaTEarly();
+        double betaDeltaTLate = this.params.impedance().betaDeltaTLate();
 
-		boolean equalOrBetterSearchImpedance = route1.searchImpedance >= 1.0 * route2.searchImpedance + 0.0;
-		boolean betterSearchImpedance = route1.searchImpedance > 1.0 * route2.searchImpedance + 0.0;
+        for (int sample = 0; sample < samples; sample++) {
+            double time = startTime + sample * stepSize;
+            double utilitiesSum = 0;
+            for (int i = 0; i < potentialRoutes.length; i++) {
+                FoundRoute route = potentialRoutes[i];
+                double routeDepTime = route.stop2stopRoute.depTime - route.originConnectedStop.walkTime();
 
-		boolean hasStrictInequality = isStrictlyContained || lessTransfers || betterSearchImpedance;
+                double deltaTEarly = this.deltaTCalculator.calculateDeltaTEarly(routeDepTime, time, time + stepSize);
+                double deltaTLate = this.deltaTCalculator.calculateDeltaTLate(routeDepTime, time, time + stepSize);
 
-		return isContained && equalOrLessTransfers && equalOrBetterSearchImpedance && hasStrictInequality;
-	}
-
-	private void sortRoutesByDepartureTime(Map<String, List<FoundRoute>> foundRoutes) {
-		for (List<FoundRoute> routes : foundRoutes.values()) {
-			routes.sort(UmlegoWorker::compareFoundRoutesByDepartureTime);
-		}
-	}
-
-	private void calculateRouteCharacteristics(Map<String, List<FoundRoute>> foundRoutes) {
-		for (List<FoundRoute> routes : foundRoutes.values()) {
-			for (FoundRoute route : routes) {
-				calculateRouteCharacteristics(route);
-			}
-		}
-	}
-
-	private void calculateOriginality(Map<String, List<FoundRoute>> foundRoutes) {
-		for (List<FoundRoute> routes : foundRoutes.values()) {
-			calculateOriginality(routes);
-		}
-	}
-
-	private void calculateRouteCharacteristics(FoundRoute route) {
-		double inVehicleTime = 0;
-		double accessTime = route.originConnectedStop.walkTime();
-		double egressTime = route.destinationConnectedStop.walkTime();
-		double walkTime = 0;
-		double transferWaitTime = 0;
-		double transferCount = route.stop2stopRoute.transfers;
-
-		boolean hadTransferBefore = false;
-		int additionalStopCount = 0;
-		for (RaptorRoute.RoutePart part : route.stop2stopRoute.routeParts) {
-			if (part.line == null) {
-				// it is a transfer
-				walkTime += (part.arrivalTime - part.depTime);
-				hadTransferBefore = true;
-			} else {
-				if (hadTransferBefore) {
-					transferWaitTime += (part.vehicleDepTime - part.depTime);
-				}
-				inVehicleTime += (part.arrivalTime - part.vehicleDepTime);
-				hadTransferBefore = false;
-				int startIndex = -1;
-				int endIndex = -1;
-				List<TransitRouteStop> stops = part.route.getStops();
-				for (int i = 0; i < stops.size(); i++) {
-					TransitRouteStop routeStop = stops.get(i);
-					if (routeStop.getStopFacility().getId().equals(part.toStop.getId()) && startIndex >= 0) {
-						endIndex = i;
-						break;
-					}
-					if (routeStop.getStopFacility().getId().equals(part.fromStop.getId())) {
-						startIndex = i;
-					}
-				}
-				if (startIndex >= 0 && endIndex >= 0) {
-					additionalStopCount += (endIndex - startIndex - 1);
-				}
-			}
-		}
-
-		double expectedTotalTime = route.stop2stopRoute.routeParts.get(route.stop2stopRoute.routeParts.size() - 1).arrivalTime - route.stop2stopRoute.routeParts.get(0).vehicleDepTime;
-		if ((walkTime + transferWaitTime + inVehicleTime) != expectedTotalTime) {
-			System.err.println("INCONSISTENT TIMES " + route.stop2stopRoute.getRouteAsString());
-		}
-		double totalTravelTime = expectedTotalTime + accessTime + egressTime;
-
-		PerceivedJourneyTimeParameters pjtParams = this.params.pjt();
-		route.perceivedJourneyTimeMin = pjtParams.betaInVehicleTime() * (inVehicleTime / 60.0)
-				+ pjtParams.betaAccessTime() * (accessTime / 60.0)
-				+ pjtParams.betaEgressTime() * (egressTime / 60.0)
-				+ pjtParams.betaWalkTime() * (walkTime / 60.0)
-				+ pjtParams.betaTransferWaitTime() * (transferWaitTime / 60.0)
-				+ transferCount * (pjtParams.transferFix() + pjtParams.transferTraveltimeFactor() * (totalTravelTime / 60.0))
-				+ (pjtParams.secondsPerAdditionalStop() / 60.0) * additionalStopCount;
-
-		SearchImpedanceParameters searchParams = this.params.search();
-		route.searchImpedance =
-				searchParams.betaInVehicleTime() * (inVehicleTime / 60.0)
-						+ searchParams.betaAccessTime() * (accessTime / 60.0)
-						+ searchParams.betaEgressTime() * (egressTime / 60.0)
-						+ searchParams.betaWalkTime() * (walkTime / 60.0)
-						+ searchParams.betaTransferWaitTime() * (transferWaitTime / 60.0)
-						+ searchParams.betaTransferCount() * transferCount;
-	}
-
-	private void calculateOriginality(List<FoundRoute> routes) {
-		routes.sort(UmlegoWorker::compareFoundRoutesByDepartureTime);
-		for (int i = 0; i < routes.size(); i++) {
-			FoundRoute route1 = routes.get(i);
-			int countEqualRoutes = 1; // comparison with itself would always result in equality
-
-			// search for equal routes before this route
-			for (int j = i-1; j >= 0; j--) {
-				FoundRoute route2 = routes.get(j);
-				if (route1.stop2stopRoute.depTime != route2.stop2stopRoute.depTime) {
-					break; // because the routes are sorted, there cannot be any more equal routes
-				}
-
-				boolean areEqual = (route1.stop2stopRoute.depTime == route2.stop2stopRoute.depTime)
-						&& (route1.stop2stopRoute.arrTime == route2.stop2stopRoute.arrTime)
-						&& (route1.searchImpedance == route2.searchImpedance)
-						&& route1.stop2stopRoute.transfers == route2.stop2stopRoute.transfers;
-				if (areEqual) {
-					countEqualRoutes++;
-				}
-			}
-			// search for equal routes after this route
-			for (int j = i+1; j < routes.size(); j++) {
-				FoundRoute route2 = routes.get(j);
-				if (route1.stop2stopRoute.depTime != route2.stop2stopRoute.depTime) {
-					break; // because the routes are sorted, there cannot be any more equal routes
-				}
-
-				boolean areEqual = (route1.stop2stopRoute.depTime == route2.stop2stopRoute.depTime)
-						&& (route1.stop2stopRoute.arrTime == route2.stop2stopRoute.arrTime)
-						&& (route1.searchImpedance == route2.searchImpedance)
-						&& route1.stop2stopRoute.transfers == route2.stop2stopRoute.transfers;
-				if (areEqual) {
-					countEqualRoutes++;
-				}
-			}
-			route1.originality = 1.0 / countEqualRoutes;
-		}
-	}
-
-	private WorkResult assignDemand(String originZone, Map<String, List<FoundRoute>> foundRoutes) throws ZoneNotFoundException {
-		sortRoutesByDepartureTime(foundRoutes);
-		UnroutableDemand unroutableDemand = new UnroutableDemand();
-		for (String destinationZone : this.destinationZoneIds) {
-			var routes = foundRoutes.get(destinationZone);
-			if (routes == null || routes.isEmpty()) {
-				double sum = 0;
-				for (String matrixName : this.demandMatrixNames) {
-					double value = this.demand.getMatrixValue(originZone, destinationZone, matrixName);
-					sum += value;
-				}
-				if (sum > 0) {
-					unroutableDemand.addPart(new UnroutableDemandPart(originZone, destinationZone, sum));
-				}
-			} else {
-				for (String matrixName : this.demandMatrixNames) {
-					double value = this.demand.getMatrixValue(originZone, destinationZone, matrixName);
-					if (value > 0) {
-						int matrixNumber = Integer.parseInt(matrixName);
-						double startTime = (matrixNumber - 1) * 10 * 60; // 10-minute time slots, in seconds TODO: make configurable
-						double endTime = (matrixNumber) * 10 * 60;
-						assignDemand(originZone, destinationZone, startTime, endTime, value, routes, unroutableDemand);
-					}
-				}
-			}
-		}
-		return new WorkResult(originZone, foundRoutes, unroutableDemand);
-	}
-
-	private void assignDemand(String originZone, String destinationZone, double startTime, double endTime, double odDemand, List<FoundRoute> routes, UnroutableDemand unroutableDemand) {
-		FoundRoute[] potentialRoutes;
-		boolean limit = this.params.routeSelection().limitSelectionToTimewindow();
-		if (limit) {
-			double earliestDeparture = startTime - this.params.routeSelection().beforeTimewindow();
-			double latestDeparture = endTime + this.params.routeSelection().afterTimewindow();
-			potentialRoutes = routes.stream().filter(route -> ((route.stop2stopRoute.depTime - route.originConnectedStop.walkTime()) >= earliestDeparture)
-					&& ((route.stop2stopRoute.depTime - route.originConnectedStop.walkTime() <= latestDeparture))).toList().toArray(new FoundRoute[0]);
-		} else {
-			potentialRoutes = routes.toArray(new FoundRoute[0]);
-		}
-		if (potentialRoutes.length == 0) {
-			unroutableDemand.addPart(new UnroutableDemandPart(originZone, destinationZone, odDemand));
-			return;
-		}
-		double timeWindow = endTime - startTime;
-		double stepSize = 60.0; // sample every minute
-		int samples = (int) (timeWindow / stepSize);
-		double sharePerSample = 1.0 / ((double) samples);
-		double[] impedances = new double[potentialRoutes.length];
-		double[] deltas = new double[potentialRoutes.length];
-		double minImpedance = Double.POSITIVE_INFINITY;
-		double[] routeUtilities = new double[potentialRoutes.length];
-		double betaPJT = this.params.impedance().betaPerceivedJourneyTime();
-		double betaDeltaTEarly = this.params.impedance().betaDeltaTEarly();
-		double betaDeltaTLate = this.params.impedance().betaDeltaTLate();
-
-		for (int sample = 0; sample < samples; sample++) {
-			double time = startTime + sample * stepSize;
-			double utilitiesSum = 0;
-			for (int i = 0; i < potentialRoutes.length; i++) {
-				FoundRoute route = potentialRoutes[i];
-				double routeDepTime = route.stop2stopRoute.depTime - route.originConnectedStop.walkTime();
-
-				double deltaTEarly = this.deltaTCalculator.calculateDeltaTEarly(routeDepTime, time, time + stepSize);
-				double deltaTLate = this.deltaTCalculator.calculateDeltaTLate(routeDepTime, time, time + stepSize);
-
-				// one of both must be zero, so we can sum them up
-				deltas[i] = Math.abs(deltaTEarly + deltaTLate);
-				double impedance = betaPJT * route.perceivedJourneyTimeMin
+                // one of both must be zero, so we can sum them up
+                deltas[i] = Math.abs(deltaTEarly + deltaTLate);
+                double impedance = betaPJT * route.perceivedJourneyTimeMin
                         + betaDeltaTEarly * (deltaTEarly / 60.0) + betaDeltaTLate * (deltaTLate / 60.0);
-				impedances[i] = impedance;
-				if (impedance < minImpedance) {
-					minImpedance = impedance;
-				}
-			}
-			for (int i = 0; i < potentialRoutes.length; i++) {
-				double impedance = impedances[i];
-				double utility = utilityCalculator.calculateUtility(impedance, minImpedance);
-				routeUtilities[i] = utility * potentialRoutes[i].originality;
-				utilitiesSum += routeUtilities[i];
-			}
-			for (int i = 0; i < potentialRoutes.length; i++) {
-				double delta = deltas[i];
-				double routeShare = routeUtilities[i] / utilitiesSum;
-				double routeDemand = odDemand * sharePerSample * routeShare;
-				FoundRoute route = potentialRoutes[i];
-				route.demand += routeDemand;
-				route.adaptationTime += delta * routeDemand;
-			}
-		}
-	}
+                impedances[i] = impedance;
+                if (impedance < minImpedance) {
+                    minImpedance = impedance;
+                }
+            }
+            for (int i = 0; i < potentialRoutes.length; i++) {
+                double impedance = impedances[i];
+                double utility = utilityCalculator.calculateUtility(impedance, minImpedance);
+                routeUtilities[i] = utility * potentialRoutes[i].originality;
+                utilitiesSum += routeUtilities[i];
+            }
+            for (int i = 0; i < potentialRoutes.length; i++) {
+                double delta = deltas[i];
+                double routeShare = routeUtilities[i] / utilitiesSum;
+                double routeDemand = odDemand * sharePerSample * routeShare;
+                FoundRoute route = potentialRoutes[i];
+                route.demand += routeDemand;
+                route.adaptationTime += delta * routeDemand;
+            }
+        }
+    }
 
-	private static int compareFoundRoutesByDepartureTime(FoundRoute o1, FoundRoute o2) {
-		if (o1.stop2stopRoute.depTime < o2.stop2stopRoute.depTime) {
-			return -1;
-		}
-		if (o1.stop2stopRoute.depTime > o2.stop2stopRoute.depTime) {
-			return +1;
-		}
-		if (o1.stop2stopRoute.travelTimeWithoutAccess < o2.stop2stopRoute.travelTimeWithoutAccess) {
-			return -1;
-		}
-		if (o1.stop2stopRoute.travelTimeWithoutAccess > o2.stop2stopRoute.travelTimeWithoutAccess) {
-			return +1;
-		}
-		return Integer.compare(o1.stop2stopRoute.transfers, o2.stop2stopRoute.transfers);
-	}
-
-	public record WorkItem(
-			String originZone,
-			CompletableFuture<WorkResult> result
-	) {
-	}
-
-	public record WorkResult(
-			String originZone,
-			Map<String, List<FoundRoute>> routesPerDestinationZone,
-			UnroutableDemand unroutableDemand
-	) {
-	}
 }

--- a/src/main/java/ch/sbb/matsim/umlego/WorkItem.java
+++ b/src/main/java/ch/sbb/matsim/umlego/WorkItem.java
@@ -1,0 +1,9 @@
+package ch.sbb.matsim.umlego;
+
+import java.util.concurrent.CompletableFuture;
+
+public record WorkItem(
+        String originZone,
+        CompletableFuture<WorkResult> result
+) {
+}

--- a/src/main/java/ch/sbb/matsim/umlego/WorkItem.java
+++ b/src/main/java/ch/sbb/matsim/umlego/WorkItem.java
@@ -2,8 +2,25 @@ package ch.sbb.matsim.umlego;
 
 import java.util.concurrent.CompletableFuture;
 
-public record WorkItem(
-        String originZone,
-        CompletableFuture<WorkResult> result
-) {
+/**
+ * The {@code WorkItem} interface defines a unit of work that can be processed by a worker.
+ */
+public interface WorkItem {
+
+    /**
+     * Returns the origin zone for this work item.
+     */
+    String originZone();
+
+    /**
+     * Returns a CompletableFuture that will be completed with the last result of processing this work item.
+     */
+    CompletableFuture<WorkResult> result();
+
+    /**
+     * Returns a iterable of CompletableFutures for work items that produce multiple results.
+     */
+    Iterable<CompletableFuture<WorkResult>> results();
+
+
 }

--- a/src/main/java/ch/sbb/matsim/umlego/WorkResult.java
+++ b/src/main/java/ch/sbb/matsim/umlego/WorkResult.java
@@ -1,0 +1,13 @@
+package ch.sbb.matsim.umlego;
+
+import ch.sbb.matsim.umlego.demand.UnroutableDemand;
+
+import java.util.List;
+import java.util.Map;
+
+public record WorkResult(
+        String originZone,
+        Map<String, List<FoundRoute>> routesPerDestinationZone,
+        UnroutableDemand unroutableDemand
+) {
+}

--- a/src/main/java/ch/sbb/matsim/umlego/WorkResult.java
+++ b/src/main/java/ch/sbb/matsim/umlego/WorkResult.java
@@ -5,6 +5,9 @@ import ch.sbb.matsim.umlego.demand.UnroutableDemand;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * WorkResult represents the result of processing a {@link WorkItem}.
+ */
 public record WorkResult(
         String originZone,
         Map<String, List<FoundRoute>> routesPerDestinationZone,

--- a/src/main/java/ch/sbb/matsim/umlego/WorkerFactory.java
+++ b/src/main/java/ch/sbb/matsim/umlego/WorkerFactory.java
@@ -10,6 +10,7 @@ import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 
 
 /**
@@ -25,4 +26,14 @@ public interface WorkerFactory {
                                 Map<String, List<ZoneConnections.ConnectedStop>> stopsPerZone,
                                 Map<String, Map<TransitStopFacility, ZoneConnections.ConnectedStop>> stopLookupPerDestination,
                                 DeltaTCalculator deltaTCalculator);
+
+
+    /**
+     * Creates a work item with the specified origin zone.
+     */
+    default WorkItem createWorkItem(String originZone) {
+        CompletableFuture<WorkResult> future = new CompletableFuture<>();
+        return new UmlegoWorkItem(originZone, List.of(future));
+    }
+
 }

--- a/src/main/java/ch/sbb/matsim/umlego/WorkerFactory.java
+++ b/src/main/java/ch/sbb/matsim/umlego/WorkerFactory.java
@@ -1,0 +1,28 @@
+package ch.sbb.matsim.umlego;
+
+import ch.sbb.matsim.routing.pt.raptor.RaptorParameters;
+import ch.sbb.matsim.routing.pt.raptor.SwissRailRaptor;
+import ch.sbb.matsim.umlego.config.UmlegoParameters;
+import ch.sbb.matsim.umlego.deltat.DeltaTCalculator;
+import ch.sbb.matsim.umlego.matrix.DemandMatrices;
+import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+
+
+/**
+ * The {@code WorkerFactory} interface defines a factory for creating workers that process work items in a multi-threaded environment.
+ */
+public interface WorkerFactory {
+
+    /**
+     * Creates a worker that processes work items from the provided queue.
+     */
+    AbstractWorker createWorker(BlockingQueue<WorkItem> workerQueue, UmlegoParameters params, DemandMatrices demand,
+                                SwissRailRaptor raptor, RaptorParameters raptorParams, List<String> destinationZoneIds,
+                                Map<String, List<ZoneConnections.ConnectedStop>> stopsPerZone,
+                                Map<String, Map<TransitStopFacility, ZoneConnections.ConnectedStop>> stopLookupPerDestination,
+                                DeltaTCalculator deltaTCalculator);
+}

--- a/src/main/java/ch/sbb/matsim/umlego/writers/PutSurveyWriter.java
+++ b/src/main/java/ch/sbb/matsim/umlego/writers/PutSurveyWriter.java
@@ -21,7 +21,7 @@ package ch.sbb.matsim.umlego.writers;
 
 import ch.sbb.matsim.routing.pt.raptor.RaptorRoute;
 import ch.sbb.matsim.routing.pt.raptor.RaptorRoute.RoutePart;
-import ch.sbb.matsim.umlego.Umlego.FoundRoute;
+import ch.sbb.matsim.umlego.FoundRoute;
 import org.matsim.core.utils.misc.Time;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
 

--- a/src/main/java/ch/sbb/matsim/umlego/writers/UmlegoBlpWriter.java
+++ b/src/main/java/ch/sbb/matsim/umlego/writers/UmlegoBlpWriter.java
@@ -20,7 +20,7 @@
 package ch.sbb.matsim.umlego.writers;
 
 import ch.sbb.matsim.routing.pt.raptor.RaptorRoute.RoutePart;
-import ch.sbb.matsim.umlego.Umlego.FoundRoute;
+import ch.sbb.matsim.umlego.FoundRoute;
 import ch.sbb.matsim.umlego.writers.types.volume.Journey;
 import ch.sbb.matsim.umlego.writers.types.volume.JourneyItem;
 import ch.sbb.matsim.umlego.writers.types.volume.TrainNo;

--- a/src/main/java/ch/sbb/matsim/umlego/writers/UmlegoCsvWriter.java
+++ b/src/main/java/ch/sbb/matsim/umlego/writers/UmlegoCsvWriter.java
@@ -19,7 +19,7 @@
 
 package ch.sbb.matsim.umlego.writers;
 
-import ch.sbb.matsim.umlego.Umlego.FoundRoute;
+import ch.sbb.matsim.umlego.FoundRoute;
 import ch.sbb.matsim.umlego.UmlegoResultWorker;
 import com.opencsv.CSVWriter;
 import org.matsim.core.utils.misc.Time;

--- a/src/main/java/ch/sbb/matsim/umlego/writers/UmlegoSkimWriter.java
+++ b/src/main/java/ch/sbb/matsim/umlego/writers/UmlegoSkimWriter.java
@@ -1,6 +1,6 @@
 package ch.sbb.matsim.umlego.writers;
 
-import ch.sbb.matsim.umlego.Umlego;
+import ch.sbb.matsim.umlego.FoundRoute;
 import ch.sbb.matsim.umlego.UmlegoResultWorker;
 import ch.sbb.matsim.umlego.UmlegoSkimCalculator;
 import ch.sbb.matsim.umlego.writers.types.skim.ODPair;
@@ -49,7 +49,7 @@ public final class UmlegoSkimWriter implements UmlegoWriter {
     }
 
     @Override
-    public void writeRoute(String origZone, String destZone, Umlego.FoundRoute route) {
+    public void writeRoute(String origZone, String destZone, FoundRoute route) {
         // Nothing needs to be done here
     }
 

--- a/src/main/java/ch/sbb/matsim/umlego/writers/UmlegoWriter.java
+++ b/src/main/java/ch/sbb/matsim/umlego/writers/UmlegoWriter.java
@@ -1,6 +1,6 @@
 package ch.sbb.matsim.umlego.writers;
 
-import ch.sbb.matsim.umlego.Umlego.FoundRoute;
+import ch.sbb.matsim.umlego.FoundRoute;
 
 /**
  * An interface for a writer for Umlego.

--- a/src/main/java/ch/sbb/matsim/umlego/writers/types/skim/SkimCalculator.java
+++ b/src/main/java/ch/sbb/matsim/umlego/writers/types/skim/SkimCalculator.java
@@ -1,6 +1,6 @@
 package ch.sbb.matsim.umlego.writers.types.skim;
 
-import ch.sbb.matsim.umlego.Umlego.FoundRoute;
+import ch.sbb.matsim.umlego.FoundRoute;
 
 /**
  * The SkimCalculator interface defines the contract for calculating skims based on routes and destination zones.

--- a/src/main/java/ch/sbb/matsim/umlego/writers/types/skim/SkimDemand.java
+++ b/src/main/java/ch/sbb/matsim/umlego/writers/types/skim/SkimDemand.java
@@ -1,6 +1,6 @@
 package ch.sbb.matsim.umlego.writers.types.skim;
 
-import ch.sbb.matsim.umlego.Umlego.FoundRoute;
+import ch.sbb.matsim.umlego.FoundRoute;
 
 public class SkimDemand implements SkimCalculator {
 

--- a/src/main/java/ch/sbb/matsim/umlego/writers/types/skim/SkimJourneyTime.java
+++ b/src/main/java/ch/sbb/matsim/umlego/writers/types/skim/SkimJourneyTime.java
@@ -1,6 +1,6 @@
 package ch.sbb.matsim.umlego.writers.types.skim;
 
-import ch.sbb.matsim.umlego.Umlego.FoundRoute;
+import ch.sbb.matsim.umlego.FoundRoute;
 
 public class SkimJourneyTime implements SkimCalculator {
 

--- a/src/main/java/ch/sbb/matsim/umlego/writers/types/skim/SkimNumberOfRoutes.java
+++ b/src/main/java/ch/sbb/matsim/umlego/writers/types/skim/SkimNumberOfRoutes.java
@@ -1,6 +1,6 @@
 package ch.sbb.matsim.umlego.writers.types.skim;
 
-import ch.sbb.matsim.umlego.Umlego.FoundRoute;
+import ch.sbb.matsim.umlego.FoundRoute;
 
 public class SkimNumberOfRoutes implements SkimCalculator {
 

--- a/src/main/java/ch/sbb/matsim/umlego/writers/types/skim/SkimWeightedAdaptationTime.java
+++ b/src/main/java/ch/sbb/matsim/umlego/writers/types/skim/SkimWeightedAdaptationTime.java
@@ -1,6 +1,6 @@
 package ch.sbb.matsim.umlego.writers.types.skim;
 
-import ch.sbb.matsim.umlego.Umlego.FoundRoute;
+import ch.sbb.matsim.umlego.FoundRoute;
 
 public class SkimWeightedAdaptationTime implements SkimCalculator {
 

--- a/src/main/java/ch/sbb/matsim/umlego/writers/types/skim/SkimWeightedJourneyTime.java
+++ b/src/main/java/ch/sbb/matsim/umlego/writers/types/skim/SkimWeightedJourneyTime.java
@@ -1,6 +1,6 @@
 package ch.sbb.matsim.umlego.writers.types.skim;
 
-import ch.sbb.matsim.umlego.Umlego.FoundRoute;
+import ch.sbb.matsim.umlego.FoundRoute;
 
 public class SkimWeightedJourneyTime implements SkimCalculator {
 

--- a/src/main/java/ch/sbb/matsim/umlego/writers/types/skim/SkimWeightedTransfers.java
+++ b/src/main/java/ch/sbb/matsim/umlego/writers/types/skim/SkimWeightedTransfers.java
@@ -1,6 +1,6 @@
 package ch.sbb.matsim.umlego.writers.types.skim;
 
-import ch.sbb.matsim.umlego.Umlego.FoundRoute;
+import ch.sbb.matsim.umlego.FoundRoute;
 
 public class SkimWeightedTransfers implements SkimCalculator {
 

--- a/src/test/java/ch/sbb/matsim/umlego/it/UmlegoITListener.java
+++ b/src/test/java/ch/sbb/matsim/umlego/it/UmlegoITListener.java
@@ -1,6 +1,6 @@
 package ch.sbb.matsim.umlego.it;
 
-import ch.sbb.matsim.umlego.Umlego.FoundRoute;
+import ch.sbb.matsim.umlego.FoundRoute;
 import ch.sbb.matsim.umlego.UmlegoListener;
 
 import java.util.ArrayList;


### PR DESCRIPTION

This PR makes the worker system more flexible and extensible by:
- Allowing different types of work items to be processed
- Supporting multiple results per work item
- Providing a cleaner abstraction for work item processing
- Implementations can extend the existing pipeline to implement their own workflows

## Changes
- Converted `WorkItem` from a record to an interface to allow for different implementations
- Introduced `UmlegoWorkItem` as the first concrete implementation
- Added support for multiple results per work item through the `results()` method
- Improved documentation with JavaDoc comments
- Added a default `createWorkItem` method to `WorkerFactory`

## Note
This is part of an ongoing refactoring effort. The changes to the architecture are not complete yet. As a next step, the `ResultWorker` needs to be generalized as well to handle different kinds of results during each stage of the pipeline.