### PR TITLE
Generalize WorkResults

### DIFF
--- a/src/main/java/ch/sbb/matsim/umlego/AbstractWorker.java
+++ b/src/main/java/ch/sbb/matsim/umlego/AbstractWorker.java
@@ -24,7 +24,7 @@ public abstract class AbstractWorker implements Runnable {
                 if (item.originZone() == null) {
                     return;
                 }
-                WorkResult result = processOriginZone(item);
+                UmlegoWorkResult result = processOriginZone(item);
                 item.result().complete(result);
             } catch (InterruptedException | ZoneNotFoundException e) {
                 throw new RuntimeException(e);
@@ -32,6 +32,6 @@ public abstract class AbstractWorker implements Runnable {
         }
     }
 
-    abstract protected WorkResult processOriginZone(WorkItem item);
+    abstract protected UmlegoWorkResult processOriginZone(WorkItem item);
 
 }

--- a/src/main/java/ch/sbb/matsim/umlego/AbstractWorker.java
+++ b/src/main/java/ch/sbb/matsim/umlego/AbstractWorker.java
@@ -7,31 +7,30 @@ import java.util.concurrent.BlockingQueue;
 /**
  * Base class for workers that process work items from a blocking queue.
  */
-public abstract class AbstractWorker implements Runnable {
+public abstract class AbstractWorker<T extends WorkItem> implements Runnable {
 
-    protected final BlockingQueue<WorkItem> workerQueue;
+    protected final BlockingQueue<T> workerQueue;
 
-    protected AbstractWorker(BlockingQueue<WorkItem> workerQueue) {
+    protected AbstractWorker(BlockingQueue<T> workerQueue) {
         this.workerQueue = workerQueue;
     }
 
     @Override
     public final void run() {
         while (true) {
-            WorkItem item = null;
+            T item = null;
             try {
                 item = this.workerQueue.take();
                 if (item.originZone() == null) {
                     return;
                 }
-                UmlegoWorkResult result = processOriginZone(item);
-                item.result().complete(result);
+                processOriginZone(item);
             } catch (InterruptedException | ZoneNotFoundException e) {
                 throw new RuntimeException(e);
             }
         }
     }
 
-    abstract protected UmlegoWorkResult processOriginZone(WorkItem item);
+    abstract protected void processOriginZone(T item);
 
 }

--- a/src/main/java/ch/sbb/matsim/umlego/UmlegoResultWorker.java
+++ b/src/main/java/ch/sbb/matsim/umlego/UmlegoResultWorker.java
@@ -127,7 +127,8 @@ public class UmlegoResultWorker implements Runnable {
         try (UmlegoWriters writers = this.getWriters()) {
             while (true) {
                 Future<WorkResult> futureResult = this.queue.take();
-                WorkResult result = futureResult.get();
+                // TODO: handle different types
+                UmlegoWorkResult result = (UmlegoWorkResult) futureResult.get();
                 if (result.originZone() == null) {
                     // end marker, the work is done
                     break;

--- a/src/main/java/ch/sbb/matsim/umlego/UmlegoWorkItem.java
+++ b/src/main/java/ch/sbb/matsim/umlego/UmlegoWorkItem.java
@@ -11,7 +11,9 @@ public record UmlegoWorkItem(
         List<CompletableFuture<WorkResult>> results
 ) implements WorkItem {
 
-    @Override
+    /**
+     * Return the only result of this work item. Results should never contain more than one result.
+     */
     public CompletableFuture<WorkResult> result() {
         return results.getLast();
     }

--- a/src/main/java/ch/sbb/matsim/umlego/UmlegoWorkResult.java
+++ b/src/main/java/ch/sbb/matsim/umlego/UmlegoWorkResult.java
@@ -1,0 +1,16 @@
+package ch.sbb.matsim.umlego;
+
+import ch.sbb.matsim.umlego.demand.UnroutableDemand;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * WorkResult represents the result of processing a {@link WorkItem}.
+ */
+public record UmlegoWorkResult(
+        String originZone,
+        Map<String, List<FoundRoute>> routesPerDestinationZone,
+        UnroutableDemand unroutableDemand
+) implements WorkResult {
+}

--- a/src/main/java/ch/sbb/matsim/umlego/UmlegoWorker.java
+++ b/src/main/java/ch/sbb/matsim/umlego/UmlegoWorker.java
@@ -28,7 +28,7 @@ import java.util.concurrent.BlockingQueue;
 /**
  * @author mrieser / Simunto
  */
-public class UmlegoWorker extends AbstractWorker {
+public class UmlegoWorker extends AbstractWorker<UmlegoWorkItem> {
 
     private final UmlegoParameters params;
     private final DemandMatrices demand;
@@ -41,7 +41,7 @@ public class UmlegoWorker extends AbstractWorker {
     private final RouteUtilityCalculator utilityCalculator;
     private final DeltaTCalculator deltaTCalculator;
 
-    public UmlegoWorker(BlockingQueue<WorkItem> workerQueue,
+    public UmlegoWorker(BlockingQueue<UmlegoWorkItem> workerQueue,
                         UmlegoParameters params,
                         DemandMatrices demand,
                         SwissRailRaptor raptor,
@@ -104,12 +104,14 @@ public class UmlegoWorker extends AbstractWorker {
     }
 
     @Override
-    protected UmlegoWorkResult processOriginZone(WorkItem workItem) throws ZoneNotFoundException {
+    protected void processOriginZone(UmlegoWorkItem workItem) throws ZoneNotFoundException {
         Map<String, List<FoundRoute>> foundRoutes = calculateRoutesForZone(workItem.originZone());
         calculateRouteCharacteristics(foundRoutes);
         filterRoutes(foundRoutes);
         calculateOriginality(foundRoutes);
-        return assignDemand(workItem.originZone(), foundRoutes);
+
+        UmlegoWorkResult result = assignDemand(workItem.originZone(), foundRoutes);
+        workItem.result().complete(result);
     }
 
     protected final Map<String, List<FoundRoute>> calculateRoutesForZone(String originZone) throws ZoneNotFoundException {

--- a/src/main/java/ch/sbb/matsim/umlego/UmlegoWorker.java
+++ b/src/main/java/ch/sbb/matsim/umlego/UmlegoWorker.java
@@ -104,7 +104,7 @@ public class UmlegoWorker extends AbstractWorker {
     }
 
     @Override
-    protected WorkResult processOriginZone(WorkItem workItem) throws ZoneNotFoundException {
+    protected UmlegoWorkResult processOriginZone(WorkItem workItem) throws ZoneNotFoundException {
         Map<String, List<FoundRoute>> foundRoutes = calculateRoutesForZone(workItem.originZone());
         calculateRouteCharacteristics(foundRoutes);
         filterRoutes(foundRoutes);
@@ -327,7 +327,7 @@ public class UmlegoWorker extends AbstractWorker {
                         + searchParams.betaTransferCount() * transferCount;
     }
 
-    protected final WorkResult assignDemand(String originZone, Map<String, List<FoundRoute>> foundRoutes) throws ZoneNotFoundException {
+    protected final UmlegoWorkResult assignDemand(String originZone, Map<String, List<FoundRoute>> foundRoutes) throws ZoneNotFoundException {
         UmlegoRouteUtils.sortRoutesByDepartureTime(foundRoutes);
         UnroutableDemand unroutableDemand = new UnroutableDemand();
         for (String destinationZone : this.destinationZoneIds) {
@@ -353,7 +353,7 @@ public class UmlegoWorker extends AbstractWorker {
                 }
             }
         }
-        return new WorkResult(originZone, foundRoutes, unroutableDemand);
+        return new UmlegoWorkResult(originZone, foundRoutes, unroutableDemand);
     }
 
     private void assignDemand(String originZone, String destinationZone, double startTime, double endTime, double odDemand, List<FoundRoute> routes, UnroutableDemand unroutableDemand) {

--- a/src/main/java/ch/sbb/matsim/umlego/UmlegoWorkflowFactory.java
+++ b/src/main/java/ch/sbb/matsim/umlego/UmlegoWorkflowFactory.java
@@ -1,0 +1,68 @@
+package ch.sbb.matsim.umlego;
+
+import ch.sbb.matsim.routing.pt.raptor.*;
+import ch.sbb.matsim.umlego.config.UmlegoParameters;
+import ch.sbb.matsim.umlego.deltat.DeltaTCalculator;
+import ch.sbb.matsim.umlego.matrix.DemandMatrices;
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Factory to create the standard Umlego workflow.
+ * This workflow computes all routes and assigns the demand once.
+ */
+public class UmlegoWorkflowFactory implements WorkflowFactory {
+
+    private final DemandMatrices demand;
+    private final Scenario scenario;
+    private final RaptorParameters raptorParams;
+    private final SwissRailRaptorData raptorData;
+
+
+    public UmlegoWorkflowFactory(DemandMatrices demand, Scenario scenario) {
+        this.demand = demand;
+        this.scenario = scenario;
+
+        // prepare SwissRailRaptor
+        // TODO: these parameters could be added to a central location.
+        raptorParams = RaptorUtils.createParameters(scenario.getConfig());
+        raptorParams.setTransferPenaltyFixCostPerTransfer(0.01);
+        raptorParams.setTransferPenaltyMinimum(0.01);
+        raptorParams.setTransferPenaltyMaximum(0.01);
+
+        RaptorStaticConfig raptorConfig = RaptorUtils.createStaticConfig(scenario.getConfig());
+        raptorConfig.setOptimization(RaptorStaticConfig.RaptorOptimization.OneToAllRouting);
+        // make sure SwissRailRaptor does not add any more transfers than what is specified in minimal transfer times:
+        raptorConfig.setBeelineWalkConnectionDistance(10.0);
+        raptorData = SwissRailRaptorData.create(this.scenario.getTransitSchedule(),
+                this.scenario.getTransitVehicles(), raptorConfig, this.scenario.getNetwork(), null);
+    }
+
+    @Override
+    public AbstractWorker createWorker(BlockingQueue<WorkItem> workerQueue, UmlegoParameters params, List<String> destinationZoneIds,
+                                       Map<String, List<ZoneConnections.ConnectedStop>> stopsPerZone,
+                                       Map<String, Map<TransitStopFacility, ZoneConnections.ConnectedStop>> stopLookupPerDestination,
+                                       DeltaTCalculator deltaTCalculator) {
+
+        SwissRailRaptor raptor = new SwissRailRaptor.Builder(raptorData, this.scenario.getConfig()).build();
+        return new UmlegoWorker(workerQueue, params, demand, raptor, raptorParams,
+                destinationZoneIds, stopsPerZone, stopLookupPerDestination, deltaTCalculator);
+    }
+
+
+    @Override
+    public WorkItem createWorkItem(String originZone) {
+        CompletableFuture<WorkResult> future = new CompletableFuture<>();
+        return new UmlegoWorkItem(originZone, List.of(future));
+    }
+
+    @Override
+    public List<WorkResultHandler<?>> createResultHandler() {
+        return List.of();
+    }
+}

--- a/src/main/java/ch/sbb/matsim/umlego/WorkItem.java
+++ b/src/main/java/ch/sbb/matsim/umlego/WorkItem.java
@@ -14,12 +14,7 @@ public interface WorkItem {
     String originZone();
 
     /**
-     * Returns a CompletableFuture that will be completed with the last result of processing this work item.
-     */
-    CompletableFuture<WorkResult> result();
-
-    /**
-     * Returns an iterable of CompletableFutures for work items that produce multiple results.
+     * Returns a list of CompletableFutures for all results of this work item.
      */
     List<CompletableFuture<WorkResult>> results();
 

--- a/src/main/java/ch/sbb/matsim/umlego/WorkItem.java
+++ b/src/main/java/ch/sbb/matsim/umlego/WorkItem.java
@@ -1,5 +1,6 @@
 package ch.sbb.matsim.umlego;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -20,7 +21,7 @@ public interface WorkItem {
     /**
      * Returns an iterable of CompletableFutures for work items that produce multiple results.
      */
-    Iterable<CompletableFuture<WorkResult>> results();
+    List<CompletableFuture<WorkResult>> results();
 
 
 }

--- a/src/main/java/ch/sbb/matsim/umlego/WorkItem.java
+++ b/src/main/java/ch/sbb/matsim/umlego/WorkItem.java
@@ -18,7 +18,7 @@ public interface WorkItem {
     CompletableFuture<WorkResult> result();
 
     /**
-     * Returns a iterable of CompletableFutures for work items that produce multiple results.
+     * Returns an iterable of CompletableFutures for work items that produce multiple results.
      */
     Iterable<CompletableFuture<WorkResult>> results();
 

--- a/src/main/java/ch/sbb/matsim/umlego/WorkResult.java
+++ b/src/main/java/ch/sbb/matsim/umlego/WorkResult.java
@@ -1,16 +1,13 @@
 package ch.sbb.matsim.umlego;
 
-import ch.sbb.matsim.umlego.demand.UnroutableDemand;
-
-import java.util.List;
-import java.util.Map;
-
 /**
- * WorkResult represents the result of processing a {@link WorkItem}.
+ * Interface representing a (partial) result of a work item processed by a worker.
  */
-public record WorkResult(
-        String originZone,
-        Map<String, List<FoundRoute>> routesPerDestinationZone,
-        UnroutableDemand unroutableDemand
-) {
+public interface WorkResult {
+
+    /**
+     * Returns the origin zone for this work item.
+     */
+    String originZone();
+
 }

--- a/src/main/java/ch/sbb/matsim/umlego/WorkResultHandler.java
+++ b/src/main/java/ch/sbb/matsim/umlego/WorkResultHandler.java
@@ -1,0 +1,15 @@
+package ch.sbb.matsim.umlego;
+
+/**
+ * Class for handling finished {@link WorkResult}s of {@link WorkItem}s.
+ * @param <T> the type of {@link WorkResult} to handle
+ */
+public interface WorkResultHandler<T extends WorkResult> {
+
+    /**
+     * Handles the result of a work item.
+     *
+     */
+    void handleResult(T result);
+
+}

--- a/src/main/java/ch/sbb/matsim/umlego/WorkResultHandler.java
+++ b/src/main/java/ch/sbb/matsim/umlego/WorkResultHandler.java
@@ -4,12 +4,20 @@ package ch.sbb.matsim.umlego;
  * Class for handling finished {@link WorkResult}s of {@link WorkItem}s.
  * @param <T> the type of {@link WorkResult} to handle
  */
-public interface WorkResultHandler<T extends WorkResult> {
+public interface WorkResultHandler<T extends WorkResult> extends AutoCloseable {
 
     /**
      * Handles the result of a work item.
      *
      */
     void handleResult(T result);
+
+    /**
+     * Closes any resources that have been opened by the handler.
+     * Called when all results have been processed.
+     */
+    @Override
+    default void close() throws Exception {
+    }
 
 }

--- a/src/main/java/ch/sbb/matsim/umlego/WorkflowFactory.java
+++ b/src/main/java/ch/sbb/matsim/umlego/WorkflowFactory.java
@@ -11,13 +11,15 @@ import java.util.concurrent.BlockingQueue;
 
 /**
  * The {@code WorkerFactory} interface defines a factory for creating workers that process work items in a multi-threaded environment.
+ *
+ * @param <T> the type of work item that the factory creates
  */
-public interface WorkflowFactory {
+public interface WorkflowFactory<T extends WorkItem> {
 
     /**
      * Creates a worker that processes work items from the provided queue.
      */
-    AbstractWorker createWorker(BlockingQueue<WorkItem> workerQueue, UmlegoParameters params,
+    AbstractWorker<T> createWorker(BlockingQueue<T> workerQueue, UmlegoParameters params,
                                 List<String> destinationZoneIds, Map<String, List<ZoneConnections.ConnectedStop>> stopsPerZone,
                                 Map<String, Map<TransitStopFacility, ZoneConnections.ConnectedStop>> stopLookupPerDestination,
                                 DeltaTCalculator deltaTCalculator);
@@ -27,12 +29,17 @@ public interface WorkflowFactory {
      * Creates a work item with the specified origin zone.
      * The length of {@link WorkItem#results()} must be equal within all work items and one {@link WorkResultHandler} must be provided for each result type.
      */
-    WorkItem createWorkItem(String originZone);
+    T createWorkItem(String originZone);
 
     /**
      * Create a list of result handlers that will be used to process the results of the work items.
      * The length of the list must be equal to {@link WorkItem#results()}.
+     *
+     * @param params             the parameters for the Umlego workflow
+     * @param outputFolder       the folder where the results should be written
+     * @param destinationZoneIds the list of destination zone IDs for which results are being processed
+     * @param listeners          the list of listeners to notify about the results
      */
-    List<WorkResultHandler<?>> createResultHandler();
+    List<WorkResultHandler<?>> createResultHandler(UmlegoParameters params, String outputFolder, List<String> destinationZoneIds, List<UmlegoListener> listeners);
 
 }

--- a/src/main/java/ch/sbb/matsim/umlego/WorkflowFactory.java
+++ b/src/main/java/ch/sbb/matsim/umlego/WorkflowFactory.java
@@ -1,39 +1,38 @@
 package ch.sbb.matsim.umlego;
 
-import ch.sbb.matsim.routing.pt.raptor.RaptorParameters;
-import ch.sbb.matsim.routing.pt.raptor.SwissRailRaptor;
 import ch.sbb.matsim.umlego.config.UmlegoParameters;
 import ch.sbb.matsim.umlego.deltat.DeltaTCalculator;
-import ch.sbb.matsim.umlego.matrix.DemandMatrices;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CompletableFuture;
 
 
 /**
  * The {@code WorkerFactory} interface defines a factory for creating workers that process work items in a multi-threaded environment.
  */
-public interface WorkerFactory {
+public interface WorkflowFactory {
 
     /**
      * Creates a worker that processes work items from the provided queue.
      */
-    AbstractWorker createWorker(BlockingQueue<WorkItem> workerQueue, UmlegoParameters params, DemandMatrices demand,
-                                SwissRailRaptor raptor, RaptorParameters raptorParams, List<String> destinationZoneIds,
-                                Map<String, List<ZoneConnections.ConnectedStop>> stopsPerZone,
+    AbstractWorker createWorker(BlockingQueue<WorkItem> workerQueue, UmlegoParameters params,
+                                List<String> destinationZoneIds, Map<String, List<ZoneConnections.ConnectedStop>> stopsPerZone,
                                 Map<String, Map<TransitStopFacility, ZoneConnections.ConnectedStop>> stopLookupPerDestination,
                                 DeltaTCalculator deltaTCalculator);
 
 
     /**
      * Creates a work item with the specified origin zone.
+     * The length of {@link WorkItem#results()} must be equal within all work items and one {@link WorkResultHandler} must be provided for each result type.
      */
-    default WorkItem createWorkItem(String originZone) {
-        CompletableFuture<WorkResult> future = new CompletableFuture<>();
-        return new UmlegoWorkItem(originZone, List.of(future));
-    }
+    WorkItem createWorkItem(String originZone);
+
+    /**
+     * Create a list of result handlers that will be used to process the results of the work items.
+     * The length of the list must be equal to {@link WorkItem#results()}.
+     */
+    List<WorkResultHandler<?>> createResultHandler();
 
 }

--- a/src/main/java/ch/sbb/matsim/umlego/writers/PutSurveyWriter.java
+++ b/src/main/java/ch/sbb/matsim/umlego/writers/PutSurveyWriter.java
@@ -26,6 +26,7 @@ import org.matsim.core.utils.misc.Time;
 import org.matsim.pt.transitSchedule.api.TransitRoute;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class PutSurveyWriter implements UmlegoWriter {
@@ -65,10 +66,13 @@ public class PutSurveyWriter implements UmlegoWriter {
      * TODO: combine with UmlegoCsvWriter.
      *
      * @param filename the name of the file to write the CSV data to
-     * @throws IOException if an I/O error occurs during file creation
      */
-    public PutSurveyWriter(String filename) throws IOException {
-        this.writer = new VisumTabularFileWriter(HEADER, COLUMNS, filename);
+    public PutSurveyWriter(String filename) {
+        try {
+            this.writer = new VisumTabularFileWriter(HEADER, COLUMNS, filename);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     @Override

--- a/src/main/java/ch/sbb/matsim/umlego/writers/ResultWriter.java
+++ b/src/main/java/ch/sbb/matsim/umlego/writers/ResultWriter.java
@@ -1,0 +1,136 @@
+package ch.sbb.matsim.umlego.writers;
+
+import ch.sbb.matsim.umlego.*;
+import ch.sbb.matsim.umlego.config.UmlegoWriterType;
+import ch.sbb.matsim.umlego.config.WriterParameters;
+import ch.sbb.matsim.umlego.demand.UnroutableDemand;
+import ch.sbb.matsim.umlego.demand.UnroutableDemandWriter;
+import ch.sbb.matsim.umlego.demand.UnroutableDemandWriterFactory;
+import org.matsim.pt.transitSchedule.api.TransitSchedule;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.zip.GZIPOutputStream;
+
+import static ch.sbb.matsim.umlego.util.PathUtil.ensureDir;
+
+/**
+ * Handler that writes {@link UmlegoWorkResult} to the configured writers and notifies listeners about the results.
+ */
+public class ResultWriter implements WorkResultHandler<UmlegoWorkResult> {
+
+    private final String outputFolder;
+    private final TransitSchedule schedule;
+    private final List<UmlegoListener> listeners;
+    private final List<UmlegoWriter> writers;
+    private final WriterParameters params;
+    private final List<String> destinationZoneIds;
+    private final UnroutableDemand unroutableDemand = new UnroutableDemand();
+
+    /**
+     * Creates a BufferedWriter for the given filename. Supports .gz compressed output.
+     */
+    public static BufferedWriter newBufferedWriter(String filename) throws IOException {
+
+        Path path = Paths.get(filename);
+        if (filename.endsWith(".gz"))
+            return new BufferedWriter(new OutputStreamWriter(new GZIPOutputStream(Files.newOutputStream(path))));
+
+        return Files.newBufferedWriter(path);
+    }
+
+    public ResultWriter(String outputFolder, TransitSchedule schedule,
+                        List<UmlegoListener> listeners,
+                        WriterParameters params, List<String> destinationZoneIds) {
+        this.outputFolder = outputFolder;
+        this.schedule = schedule;
+        this.listeners = listeners;
+        this.params = params;
+        this.destinationZoneIds = destinationZoneIds;
+        this.writers = params.writerTypes().stream().map(this::getWriter).toList();
+    }
+
+    private UmlegoWriter getWriter(UmlegoWriterType type) {
+
+        ensureDir(outputFolder);
+        return switch (type) {
+            case BLP ->
+                    new UmlegoBlpWriter(Paths.get(this.outputFolder, "belastungsteppich.csv.gz").toString(), schedule);
+            case SKIM -> {
+                Optional<UmlegoSkimCalculator> calc = this.listeners.stream()
+                        .filter(s -> s instanceof UmlegoSkimCalculator)
+                        .map(UmlegoSkimCalculator.class::cast)
+                        .findFirst();
+
+                yield new UmlegoSkimWriter(calc.orElseThrow(), Paths.get(this.outputFolder, "skims.csv.gz").toString());
+            }
+            case CSV -> new UmlegoCsvWriter(Paths.get(this.outputFolder, "connections.csv.gz").toString(), true);
+            case PutSurvey -> new PutSurveyWriter(Paths.get(this.outputFolder, "visum.net.gz").toString());
+        };
+    }
+
+    public UnroutableDemand getUnroutableDemand() {
+        return unroutableDemand;
+    }
+
+    @Override
+    public void handleResult(UmlegoWorkResult result) {
+
+        unroutableDemand.getParts().addAll(result.unroutableDemand().getParts());
+        String origZone = result.originZone();
+        Map<String, List<FoundRoute>> routesPerDestination = result.routesPerDestinationZone();
+        if (routesPerDestination == null) {
+            // looks like this zone cannot reach any destination
+            return;
+        }
+
+        for (String destZone : destinationZoneIds) {
+            if (origZone.equals(destZone)) {
+                // we're not interested in intrazonal trips
+                continue;
+            }
+            List<FoundRoute> routesToDestination = routesPerDestination.get(destZone);
+            if (routesToDestination == null || routesToDestination.isEmpty()) {
+                // looks like there are no routes to this destination from the given origin zone
+                continue;
+            }
+
+            for (FoundRoute route : routesToDestination) {
+                for (var listener : listeners) {
+                    listener.processRoute(origZone, destZone, route);
+                }
+
+                if (route.demand >= this.params.minimalDemandForWriting()) {
+                    writers.forEach(w -> w.writeRoute(origZone, destZone, route));
+                }
+            }
+
+            for (UmlegoListener listener : listeners) {
+                listener.processODPair(origZone, destZone);
+            }
+
+            writers.forEach(w -> w.writeODPair(origZone, destZone));
+        }
+
+    }
+
+    @Override
+    public void close() throws Exception {
+        // close all listeners
+        listeners.forEach(UmlegoListener::finish);
+
+        for (UmlegoWriter w : writers) {
+            w.close();
+        }
+
+        UnroutableDemandWriter demandWriter = UnroutableDemandWriterFactory.createWriter(outputFolder);
+        demandWriter.write(unroutableDemand);
+    }
+}

--- a/src/main/java/ch/sbb/matsim/umlego/writers/UmlegoCsvWriter.java
+++ b/src/main/java/ch/sbb/matsim/umlego/writers/UmlegoCsvWriter.java
@@ -25,7 +25,10 @@ import com.opencsv.CSVWriter;
 import org.matsim.core.utils.misc.Time;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Locale;
+
+import static ch.sbb.matsim.umlego.writers.ResultWriter.newBufferedWriter;
 
 public class UmlegoCsvWriter implements UmlegoWriter {
 
@@ -48,9 +51,13 @@ public class UmlegoCsvWriter implements UmlegoWriter {
     private final boolean writeDetails;
     private final CSVWriter writer;
 
-    public UmlegoCsvWriter(String filename, boolean writeDetails) throws IOException {
+    public UmlegoCsvWriter(String filename, boolean writeDetails) {
         this.writeDetails = writeDetails;
-        this.writer = new CSVWriter(UmlegoResultWorker.newBufferedWriter(filename), ',', '"', '\\', "\n");
+        try {
+            this.writer = new CSVWriter(newBufferedWriter(filename), ',', '"', '\\', "\n");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
         this.writer.writeNext(HEADER_ROW);
     }
 

--- a/src/main/java/ch/sbb/matsim/umlego/writers/UmlegoSkimWriter.java
+++ b/src/main/java/ch/sbb/matsim/umlego/writers/UmlegoSkimWriter.java
@@ -15,6 +15,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import static ch.sbb.matsim.umlego.writers.ResultWriter.newBufferedWriter;
+
 /**
  * Writes skim matrices to a CSV file.
  */
@@ -29,7 +31,7 @@ public final class UmlegoSkimWriter implements UmlegoWriter {
         this.skims = skims;
 
         try {
-            this.writer = new CSVWriter(UmlegoResultWorker.newBufferedWriter(filename), ',', '"', '\\', "\n");
+            this.writer = new CSVWriter(newBufferedWriter(filename), ',', '"', '\\', "\n");
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         };

--- a/src/main/java/ch/sbb/matsim/umlego/writers/VisumTabularFileWriter.java
+++ b/src/main/java/ch/sbb/matsim/umlego/writers/VisumTabularFileWriter.java
@@ -12,6 +12,8 @@ import org.matsim.core.utils.misc.Counter;
 import java.io.BufferedWriter;
 import java.io.IOException;
 
+import static ch.sbb.matsim.umlego.writers.ResultWriter.newBufferedWriter;
+
 /**
  * The HeaderColumnWriter allows so write a header before the comma-separated colums.
  * Used i.e. for writing Visum files.
@@ -29,7 +31,7 @@ class VisumTabularFileWriter implements AutoCloseable {
 	private final Counter counter;
 
 	VisumTabularFileWriter(final String header, final String[] columns, final String filename) throws IOException {
-		this(header, columns, UmlegoResultWorker.newBufferedWriter(filename), DEFAULT_SEPARATOR);
+		this(header, columns, newBufferedWriter(filename), DEFAULT_SEPARATOR);
 	}
 
 	private VisumTabularFileWriter(final String header, final String[] columns, final BufferedWriter writer, final String separator) throws IOException {

--- a/src/test/java/ch/sbb/matsim/umlego/it/CustomWorkflowTest.java
+++ b/src/test/java/ch/sbb/matsim/umlego/it/CustomWorkflowTest.java
@@ -1,0 +1,184 @@
+package ch.sbb.matsim.umlego.it;
+
+import ch.sbb.matsim.umlego.*;
+import ch.sbb.matsim.umlego.ZoneConnections.ConnectedStop;
+import ch.sbb.matsim.umlego.config.UmlegoParameters;
+import ch.sbb.matsim.umlego.deltat.DeltaTCalculator;
+import ch.sbb.matsim.umlego.matrix.DemandMatrices;
+import ch.sbb.matsim.umlego.matrix.DemandMatrix;
+import ch.sbb.matsim.umlego.matrix.ZonesLookup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+
+import static ch.sbb.matsim.umlego.it.UmlegoFixture.createUmlegoParameters;
+
+/**
+ * Test for the new architecture with generalized workflow.
+ */
+public class CustomWorkflowTest {
+
+    private String LAUSANNE;
+    private String GENEVE;
+    private Map<String, List<ConnectedStop>> stopsPerZone;
+    private DemandMatrices demand;
+
+    @BeforeEach
+    void setUp() {
+        UmlegoFixture fixture = new UmlegoFixture();
+
+        TransitStopFacility lausanne = fixture.buildStop("lausanne", 2532820.15, 1154661.65);
+        TransitStopFacility geneve = fixture.buildStop("geneve", 2499812.38, 1118367.70);
+
+        fixture.buildLine("testLine", List.of(lausanne, geneve), List.of("00:00", "01:00"), List.of("05:00"));
+
+        LAUSANNE = "Lausanne";
+        GENEVE = "Geneve";
+
+        var data = new HashMap<String, Integer>();
+        data.put(GENEVE, 0);
+        data.put(LAUSANNE, 1);
+
+        double[][] m = {{10, 10}, {10, 10}};
+        var matrix = new DemandMatrix(23 * 60 + 50, 24 * 60, m);
+        demand = new DemandMatrices(List.of(matrix), new ZonesLookup(data));
+
+        stopsPerZone = new HashMap<>();
+        stopsPerZone.put(GENEVE, List.of(new ConnectedStop(GENEVE, 0, geneve)));
+        stopsPerZone.put(LAUSANNE, List.of(new ConnectedStop(LAUSANNE, 0, lausanne)));
+    }
+
+    @Test
+    void testCustomWorkflow() throws Exception {
+        // Create a custom workflow factory
+        MockWorkflowFactory mockWorkflowFactory = new MockWorkflowFactory();
+
+        // Initialize Umlego with the custom workflow factory
+        Umlego umlego = new Umlego(demand, stopsPerZone, mockWorkflowFactory);
+
+        // Create a test result listener
+        TestResultListener listener = new TestResultListener();
+        umlego.addListener(listener);
+
+        // Run Umlego with custom workflow
+        var params = createUmlegoParameters();
+
+        umlego.run(List.of(LAUSANNE), List.of(GENEVE), params, 1, "");
+
+        // Verify the results
+        Assertions.assertTrue(mockWorkflowFactory.createWorkerCalled, "Worker should have been created");
+        Assertions.assertTrue(mockWorkflowFactory.createWorkItemCalled, "Work item should have been created");
+        Assertions.assertTrue(mockWorkflowFactory.createResultHandlerCalled, "Result handler should have been created");
+
+        // Verify the work items were created with the correct origin zone
+        List<MockWorkResult> results = listener.getResults();
+        Assertions.assertEquals(2, results.size(), "Should have two results");
+        Assertions.assertTrue(results.stream().allMatch(r -> LAUSANNE.equals(r.originZone())),
+                "All results should be from Lausanne");
+        Assertions.assertTrue(results.stream().anyMatch(r -> "result1".equals(r.resultType())),
+                "Should have a result of type 'result1'");
+        Assertions.assertTrue(results.stream().anyMatch(r -> "result2".equals(r.resultType())),
+                "Should have a result of type 'result2'");
+
+        // Verify the work item was processed
+        Assertions.assertTrue(mockWorkflowFactory.workItemProcessed,
+                "Work item should have been processed by the worker");
+    }
+
+    /**
+     * Mock implementation of WorkflowFactory for testing purposes.
+     */
+    private static class MockWorkflowFactory implements WorkflowFactory<UmlegoWorkItem> {
+        boolean createWorkerCalled = false;
+        boolean createWorkItemCalled = false;
+        boolean createResultHandlerCalled = false;
+        boolean workItemProcessed = false;
+
+        @Override
+        public AbstractWorker<UmlegoWorkItem> createWorker(BlockingQueue<UmlegoWorkItem> workerQueue, UmlegoParameters params,
+                                                           List<String> destinationZoneIds,
+                                                           Map<String, List<ConnectedStop>> stopsPerZone,
+                                                           Map<String, Map<TransitStopFacility, ConnectedStop>> stopLookupPerDestination,
+                                                           DeltaTCalculator deltaTCalculator) {
+            createWorkerCalled = true;
+            return new AbstractWorker<>(workerQueue) {
+                @Override
+                protected void processOriginZone(UmlegoWorkItem workItem) {
+                    workItemProcessed = true;
+
+                    for (int i = 0; i < workItem.results().size(); i++) {
+                        CompletableFuture<WorkResult> future = workItem.results().get(i);
+                        if (!future.isDone()) {
+                            future.complete(new MockWorkResult(workItem.originZone(), i == 0 ? "result1" : "result2"));
+                        }
+                    }
+                }
+            };
+        }
+
+        @Override
+        public UmlegoWorkItem createWorkItem(String originZone) {
+            createWorkItemCalled = true;
+            CompletableFuture<WorkResult> future1 = new CompletableFuture<>();
+            CompletableFuture<WorkResult> future2 = new CompletableFuture<>();
+            return new UmlegoWorkItem(originZone, List.of(future1, future2));
+        }
+
+        @Override
+        public List<WorkResultHandler<?>> createResultHandler(UmlegoParameters params, String outputFolder,
+                                                              List<String> destinationZoneIds,
+                                                              List<UmlegoListener> listeners) {
+            createResultHandlerCalled = true;
+            return List.of(new MockResultHandler(listeners), new MockResultHandler(listeners));
+        }
+    }
+
+    /**
+     * Mock implementation of WorkResult for testing purposes.
+     */
+    private record MockWorkResult(String originZone, String resultType) implements WorkResult {
+    }
+
+    /**
+     * Mock implementation of WorkResultHandler for testing purposes.
+     */
+    private record MockResultHandler(List<UmlegoListener> listeners) implements WorkResultHandler<MockWorkResult> {
+
+        @Override
+        public void handleResult(MockWorkResult result) {
+            for (UmlegoListener listener : listeners) {
+                if (listener instanceof TestResultListener testListener) {
+                    testListener.receiveResult(result);
+                }
+            }
+        }
+    }
+
+    /**
+     * Test listener to verify the workflow results.
+     */
+    private static class TestResultListener implements UmlegoListener {
+        private final List<MockWorkResult> results = new ArrayList<>();
+
+        public void receiveResult(MockWorkResult result) {
+            results.add(result);
+        }
+
+        public List<MockWorkResult> getResults() {
+            return results;
+        }
+
+        @Override
+        public void processRoute(String originZone, String destinationZone, FoundRoute route) {
+            // Not used in these tests
+        }
+    }
+}

--- a/src/test/java/ch/sbb/matsim/umlego/it/UmlegoFixture.java
+++ b/src/test/java/ch/sbb/matsim/umlego/it/UmlegoFixture.java
@@ -1,15 +1,10 @@
 package ch.sbb.matsim.umlego.it;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import ch.sbb.matsim.umlego.config.UmlegoParameters;
-import jakarta.annotation.Nullable;
+import ch.sbb.matsim.umlego.config.*;
 import org.github.gestalt.config.Gestalt;
 import org.github.gestalt.config.builder.GestaltBuilder;
 import org.github.gestalt.config.exceptions.GestaltException;
-import org.github.gestalt.config.source.*;
+import org.github.gestalt.config.source.ClassPathConfigSourceBuilder;
 import org.github.gestalt.config.yaml.YamlModuleConfigBuilder;
 import org.matsim.api.core.v01.Coord;
 import org.matsim.api.core.v01.Id;
@@ -22,14 +17,10 @@ import org.matsim.core.population.routes.NetworkRoute;
 import org.matsim.core.population.routes.RouteUtils;
 import org.matsim.core.scenario.MutableScenario;
 import org.matsim.core.scenario.ScenarioUtils.ScenarioBuilder;
-import org.matsim.pt.transitSchedule.api.Departure;
-import org.matsim.pt.transitSchedule.api.TransitLine;
-import org.matsim.pt.transitSchedule.api.TransitRoute;
-import org.matsim.pt.transitSchedule.api.TransitRouteStop;
-import org.matsim.pt.transitSchedule.api.TransitSchedule;
-import org.matsim.pt.transitSchedule.api.TransitScheduleFactory;
-import org.matsim.pt.transitSchedule.api.TransitStopFacility;
+import org.matsim.pt.transitSchedule.api.*;
 import org.matsim.vehicles.Vehicles;
+
+import java.util.*;
 
 /*package*/  public class UmlegoFixture {
 
@@ -51,6 +42,17 @@ import org.matsim.vehicles.Vehicles;
         this.schedule = this.scenario.getTransitSchedule();
         this.builder = this.schedule.getFactory();
         this.transitVehicles = this.scenario.getTransitVehicles();
+    }
+
+    public static UmlegoParameters createUmlegoParameters() {
+        SearchImpedanceParameters search = new SearchImpedanceParameters(1.0, 1.0, 1.0, 1.0, 1.0, 10.0);
+        PreselectionParameters preselection = new PreselectionParameters(2.0, 60.0);
+        PerceivedJourneyTimeParameters pjt = new PerceivedJourneyTimeParameters(1.0, 2.94, 2.94, 2.25, 1.13, 17.24, 0.03, 58.0);
+        RouteImpedanceParameters impedance = new RouteImpedanceParameters(1.0, 1.85, 1.85);
+        RouteSelectionParameters routeSelection = new RouteSelectionParameters(false, 3600.0, 3600.0, new UtilityFunctionParams(UtilityFunctionParams.Type.boxcox, Map.of("beta", 1.536, "tau", 0.5)));
+        WriterParameters writer = new WriterParameters(1e-5, Set.of());
+        return new UmlegoParameters(5, 1, search, preselection, pjt, impedance, routeSelection, writer);
+
     }
 
     public static UmlegoParameters loadTestConfig() throws GestaltException {

--- a/src/test/java/ch/sbb/matsim/umlego/it/UmlegoITTest.java
+++ b/src/test/java/ch/sbb/matsim/umlego/it/UmlegoITTest.java
@@ -2,7 +2,6 @@ package ch.sbb.matsim.umlego.it;
 
 import ch.sbb.matsim.umlego.Umlego;
 import ch.sbb.matsim.umlego.ZoneConnections.ConnectedStop;
-import ch.sbb.matsim.umlego.config.*;
 import ch.sbb.matsim.umlego.matrix.DemandMatrices;
 import ch.sbb.matsim.umlego.matrix.DemandMatrix;
 import ch.sbb.matsim.umlego.matrix.ZonesLookup;
@@ -13,20 +12,14 @@ import org.matsim.api.core.v01.Scenario;
 import org.matsim.pt.transitSchedule.api.TransitLine;
 import org.matsim.pt.transitSchedule.api.TransitStopFacility;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static ch.sbb.matsim.umlego.it.UmlegoFixture.createUmlegoParameters;
 
 public class UmlegoITTest {
-
-    UmlegoParameters createUmlegoParameters() {
-        SearchImpedanceParameters search = new SearchImpedanceParameters(1.0, 1.0, 1.0, 1.0, 1.0, 10.0);
-        PreselectionParameters preselection = new PreselectionParameters(2.0, 60.0);
-        PerceivedJourneyTimeParameters pjt = new PerceivedJourneyTimeParameters(1.0, 2.94, 2.94, 2.25, 1.13, 17.24, 0.03, 58.0);
-        RouteImpedanceParameters impedance = new RouteImpedanceParameters(1.0, 1.85, 1.85);
-        RouteSelectionParameters routeSelection = new RouteSelectionParameters(false, 3600.0, 3600.0, new UtilityFunctionParams(UtilityFunctionParams.Type.boxcox, Map.of("beta", 1.536, "tau", 0.5)));
-        WriterParameters writer = new WriterParameters(1e-5, Set.of());
-        return new UmlegoParameters(5, 1, search, preselection, pjt, impedance, routeSelection, writer);
-
-    }
 
     private TransitStopFacility getStop(Scenario scenario, String stopId) {
         return scenario.getTransitSchedule().getFacilities().get(Id.create(stopId, TransitStopFacility.class));


### PR DESCRIPTION
This PR is a follow-up to #29 in order to generalize the workflow of umlego.

The added functionality allows to define the type of work items and results per pipeline, which allows to model workflows that consist of multiple stages and may produce multiple results per origin destination pair.